### PR TITLE
feat: add base renderer interface

### DIFF
--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DataIngest, Controller } from './core';
+export * from './renderers';
 
 /** Return the version string of the viewer package. */
 export function viewerVersion(): string {

--- a/packages/viewer/src/renderers/base.ts
+++ b/packages/viewer/src/renderers/base.ts
@@ -1,0 +1,39 @@
+export interface Renderer {
+  /** Prepare WebGL resources for rendering. */
+  init(gl: WebGL2RenderingContext, canvas: HTMLCanvasElement): void;
+  /** Resize the renderer to the specified dimensions. */
+  resize(width: number, height: number): void;
+  /** Render a frame using the current data. */
+  render(): void;
+  /** Release any allocated resources. */
+  dispose(): void;
+}
+
+/**
+ * Convenience abstract class providing basic lifecycle management.
+ * Specific view modes should extend this and override `render`.
+ */
+export abstract class BaseRenderer implements Renderer {
+  protected gl: WebGL2RenderingContext | null = null;
+  protected canvas: HTMLCanvasElement | null = null;
+
+  init(gl: WebGL2RenderingContext, canvas: HTMLCanvasElement): void {
+    this.gl = gl;
+    this.canvas = canvas;
+  }
+
+  resize(width: number, height: number): void {
+    if (this.canvas) {
+      this.canvas.width = width;
+      this.canvas.height = height;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  render(): void {}
+
+  dispose(): void {
+    this.gl = null;
+    this.canvas = null;
+  }
+}

--- a/packages/viewer/src/renderers/index.ts
+++ b/packages/viewer/src/renderers/index.ts
@@ -1,0 +1,1 @@
+export * from './base';

--- a/packages/viewer/tests/base-renderer.test.ts
+++ b/packages/viewer/tests/base-renderer.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { BaseRenderer } from '../src/renderers';
+
+class DummyRenderer extends BaseRenderer {
+  public rendered = false;
+  render(): void {
+    this.rendered = true;
+  }
+}
+
+describe('BaseRenderer', () => {
+  it('manages lifecycle', () => {
+    const r = new DummyRenderer();
+    // resize before init should do nothing
+    r.resize(10, 5);
+
+    const canvas = document.createElement('canvas');
+    const gl = {} as unknown as WebGL2RenderingContext;
+
+    r.init(gl, canvas);
+    r.resize(20, 10);
+    expect(canvas.width).toBe(20);
+    expect(canvas.height).toBe(10);
+
+    r.render();
+    expect(r.rendered).toBe(true);
+
+    r.dispose();
+    // resize after dispose should not modify canvas
+    r.resize(30, 15);
+    expect(canvas.width).toBe(20);
+    expect(canvas.height).toBe(10);
+  });
+});

--- a/task.md
+++ b/task.md
@@ -38,7 +38,7 @@
 
 ## 4. Rendering Modes
 
-- [ ] Implement base renderer interface for pluggable view modes.
+- [x] Implement base renderer interface for pluggable view modes.
 - [ ] Build 2D heatmap renderer using WebGL2 textures and palettes.
 - [ ] Build 2D waterfall renderer stacking time slices vertically.
 - [ ] Build 3D waterfall renderer with heightfield mesh and optional wireframe.


### PR DESCRIPTION
## Summary
- add base renderer interface and abstract class for pluggable view modes
- expose renderer exports from library entrypoint
- test base renderer lifecycle

## Testing
- `npm --prefix packages/viewer run format`
- `npm --prefix packages/viewer run lint`
- `npm --prefix packages/viewer test`

------
https://chatgpt.com/codex/tasks/task_e_68a391d38a0c832b8806e0316f606172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed renderer APIs through the viewer package, enabling easier integration of custom rendering modes.
  - Introduced a base renderer with standardized lifecycle hooks for consistent behavior across renderers.
- Tests
  - Added comprehensive tests covering renderer initialization, resizing, rendering, and disposal flows.
- Documentation
  - Updated project task status to reflect completion of the base renderer interface implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->