### PR TITLE
feat: implement default spectrogram configuration

### DIFF
--- a/packages/viewer/src/core/controller.ts
+++ b/packages/viewer/src/core/controller.ts
@@ -1,14 +1,19 @@
-import { SpectroConfig, SpectroMeta } from '../index';
+import {
+  SpectroConfig,
+  SpectroMeta,
+  DEFAULT_SPECTRO_CONFIG,
+  DEFAULT_SPECTRO_META,
+} from '../index';
 
 /**
  * Tracks configuration and metadata and derives rendering parameters.
  */
 export class Controller {
-  private config: SpectroConfig = {};
-  private meta: SpectroMeta | null = null;
+  private config: SpectroConfig = { ...DEFAULT_SPECTRO_CONFIG };
+  private meta: SpectroMeta = { ...DEFAULT_SPECTRO_META };
 
   constructor(initial?: SpectroConfig) {
-    if (initial) this.config = { ...initial };
+    if (initial) this.setConfig(initial);
   }
 
   setConfig(next: Partial<SpectroConfig>): void {
@@ -16,14 +21,22 @@ export class Controller {
   }
 
   setMeta(meta: SpectroMeta): void {
-    this.meta = meta;
+    this.meta = { ...DEFAULT_SPECTRO_META, ...meta };
+  }
+
+  getConfig(): SpectroConfig {
+    return { ...this.config };
+  }
+
+  getMeta(): SpectroMeta {
+    return { ...this.meta };
   }
 
   /** Compute maximum rows permitted based on time window and hop size. */
   get maxRows(): number {
-    if (!this.meta) return this.config.maxRows ?? 0;
     const hopSeconds = this.meta.hopSize / this.meta.sampleRateHz;
-    const timeWindow = this.config.timeWindowSec ?? 15;
+    const timeWindow =
+      this.config.timeWindowSec ?? DEFAULT_SPECTRO_CONFIG.timeWindowSec!;
     const rows = Math.ceil(timeWindow / hopSeconds);
     const maxRows = this.config.maxRows ?? rows;
     return maxRows;

--- a/packages/viewer/tests/controller.test.ts
+++ b/packages/viewer/tests/controller.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { Controller } from '../src/core';
-import { SpectroMeta } from '../src/index';
+import {
+  SpectroMeta,
+  DEFAULT_SPECTRO_CONFIG,
+  DEFAULT_SPECTRO_META,
+} from '../src/index';
 
 describe('Controller', () => {
   it('derives maxRows from config and meta', () => {
@@ -20,5 +24,48 @@ describe('Controller', () => {
     expect(c.maxRows).toBe(10);
     c.setConfig({ maxRows: 5 });
     expect(c.maxRows).toBe(5);
+  });
+
+  it('provides default config and meta', () => {
+    const c = new Controller();
+    expect(c.getConfig()).toMatchObject({
+      timeWindowSec: DEFAULT_SPECTRO_CONFIG.timeWindowSec,
+      dbFloor: DEFAULT_SPECTRO_CONFIG.dbFloor,
+      dbCeiling: DEFAULT_SPECTRO_CONFIG.dbCeiling,
+      freqScale: DEFAULT_SPECTRO_CONFIG.freqScale,
+      palette: DEFAULT_SPECTRO_CONFIG.palette,
+    });
+    expect(c.getMeta()).toMatchObject({
+      nfft: DEFAULT_SPECTRO_META.nfft,
+      hopSize: DEFAULT_SPECTRO_META.hopSize,
+      window: DEFAULT_SPECTRO_META.window,
+    });
+  });
+
+  it('allows overriding defaults', () => {
+    const c = new Controller();
+    c.setConfig({
+      palette: 'turbo',
+      freqScale: 'linear',
+      dbFloor: -80,
+      dbCeiling: -10,
+      timeWindowSec: 10,
+    });
+    expect(c.getConfig()).toMatchObject({
+      palette: 'turbo',
+      freqScale: 'linear',
+      dbFloor: -80,
+      dbCeiling: -10,
+      timeWindowSec: 10,
+    });
+  });
+
+  it('computes maxRows from default settings', () => {
+    const c = new Controller();
+    const expected = Math.ceil(
+      DEFAULT_SPECTRO_CONFIG.timeWindowSec! /
+        (DEFAULT_SPECTRO_META.hopSize / DEFAULT_SPECTRO_META.sampleRateHz),
+    );
+    expect(c.maxRows).toBe(expected);
   });
 });

--- a/packages/viewer/tests/data-ingest.test.ts
+++ b/packages/viewer/tests/data-ingest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DataIngest, Controller } from '../src/core';
-import { SpectroMeta } from '../src/index';
+import { SpectroMeta, DEFAULT_SPECTRO_META } from '../src/index';
 
 const baseMeta: SpectroMeta = {
   streamId: 's',
@@ -15,6 +15,18 @@ const baseMeta: SpectroMeta = {
 };
 
 describe('DataIngest', () => {
+  it('initializes with default metadata', () => {
+    const controller = new Controller();
+    const ingest = new DataIngest(controller);
+    ingest.pushFrame({
+      channelId: 0,
+      frameIndex: 0,
+      timestampUs: 0,
+      bins: new Float32Array(DEFAULT_SPECTRO_META.binCount),
+    });
+    expect(ingest.getStats()).toEqual({ frameCount: 1 });
+  });
+
   it('accepts frames, enforces ordering, and reallocates on meta change', () => {
     const controller = new Controller({ timeWindowSec: 1 });
     const ingest = new DataIngest(controller);

--- a/task.md
+++ b/task.md
@@ -60,10 +60,10 @@
 
 ## 6. Default Behavior and Configuration
 
-- [ ] Set defaults: `nfft=2048`, `hopSize=512`, Hann window, time window of 15 seconds, `dBFS` range `[-100, 0]`.
-- [ ] Provide sensible defaults for `freqScale` (`log` for music, `linear` for engineering).
-- [ ] Default palette to `viridis` with option to switch to high-contrast `turbo`.
-- [ ] Ensure default time window and frame rate accommodate real-time streaming.
+- [x] Set defaults: `nfft=2048`, `hopSize=512`, Hann window, time window of 15 seconds, `dBFS` range `[-100, 0]`.
+- [x] Provide sensible defaults for `freqScale` (`log` for music, `linear` for engineering).
+- [x] Default palette to `viridis` with option to switch to high-contrast `turbo`.
+- [x] Ensure default time window and frame rate accommodate real-time streaming.
 
 ## 7. Edge Cases and Hardening
 


### PR DESCRIPTION
## Summary
- add default spectrogram metadata and configuration constants
- initialize controller and data ingestion with defaults and expose getters
- test default behaviors and overrides

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39841b054832baa150107c63e1d42