### PR TITLE
Optimize FFT with rustfft and add benchmark tests

### DIFF
--- a/web/crates/dsp_core/Cargo.toml
+++ b/web/crates/dsp_core/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-kofft = "0.1.5"
+rustfft = "6"
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4"

--- a/web/crates/dsp_core/src/lib.rs
+++ b/web/crates/dsp_core/src/lib.rs
@@ -1,96 +1,201 @@
-use wasm_bindgen::prelude::*;
+use rustfft::{num_complex::Complex32, FftPlanner};
 use std::f32::consts::PI;
+use wasm_bindgen::prelude::*;
+
+/// Full circle constant used in window and FFT calculations.
+const TWO_PI: f32 = 2.0 * PI;
+
+/// Smallest allowed reference amplitude to avoid division-by-zero and
+/// log-of-zero when converting to decibels.
+const EPSILON: f32 = 1e-12;
+
+/// Linear-to-decibel scaling factor (20 * log10(x)).
+const DB_SCALE: f32 = 20.0;
+
+/// Coefficient for the Hann window: 0.5 - 0.5 * cos(theta).
+const HANN_A0: f32 = 0.5;
+
+/// Secondary coefficient for the Hann window.
+const HANN_A1: f32 = 0.5;
+
+/// Coefficients for the Hamming window formula.
+const HAMMING_ALPHA: f32 = 0.54;
+const HAMMING_BETA: f32 = 0.46;
+
+/// Coefficients for the Blackman window formula.
+const BLACKMAN_A0: f32 = 0.42;
+const BLACKMAN_A1: f32 = 0.5;
+const BLACKMAN_A2: f32 = 0.08;
 
 // Set panic hook for better error messages in wasm
 #[wasm_bindgen(start)]
 pub fn init_panic_hook() {
-	console_error_panic_hook::set_once();
+    console_error_panic_hook::set_once();
 }
 
-/// Compute real-to-complex FFT using a working implementation.
-/// What: Returns [re0, im0, re1, im1, ...] for efficient GPU texture upload.
-/// Why: Provides working FFT while we optimize with kofft SIMD later.
+/// Compute the forward real-to-complex FFT using the `rustfft` library.
+///
+/// # What
+/// Returns a flat array `[re0, im0, re1, im1, ...]` suitable for
+/// uploading to GPU textures without additional rearrangement.
+///
+/// # Why
+/// Replaces the previous \(O(n^2)\) reference implementation with a
+/// fast \(O(n \log n)\) FFT for significant performance gains.
 #[wasm_bindgen]
 pub fn fft_real(input: &[f32]) -> Vec<f32> {
-	let n = input.len();
-	if n == 0 { return vec![]; }
-	
-	// Use a simple FFT implementation for now
-	let mut output = vec![0.0f32; 2 * n];
-	
-	// For each frequency bin
-	for k in 0..n {
-		let mut re = 0.0f32;
-		let mut im = 0.0f32;
-		
-		// Sum over all time samples
-		for (i, &x) in input.iter().enumerate() {
-			let angle = -2.0 * PI * k as f32 * i as f32 / n as f32;
-			re += x * angle.cos();
-			im += x * angle.sin();
-		}
-		
-		output[2 * k] = re;
-		output[2 * k + 1] = im;
-	}
-	
-	output
+    let n = input.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    if input.iter().any(|v| !v.is_finite()) {
+        panic!("fft_real: input contains non-finite values");
+    }
+
+    // Convert real input into complex numbers required by `rustfft`.
+    let mut buffer: Vec<Complex32> = input.iter().map(|&x| Complex32::new(x, 0.0)).collect();
+
+    // Plan and execute the FFT. Planner internally caches instances by size.
+    FftPlanner::<f32>::new()
+        .plan_fft_forward(n)
+        .process(&mut buffer);
+
+    // Flatten complex results into interleaved real/imaginary pairs.
+    let mut output = Vec::with_capacity(2 * n);
+    for c in buffer {
+        output.push(c.re);
+        output.push(c.im);
+    }
+    output
 }
 
 /// Apply window function to input buffer. What: Multiplies input by window coefficients.
 /// Why: Reduces spectral leakage in FFT analysis.
 #[wasm_bindgen]
 pub fn apply_window(input: &[f32], window_type: &str) -> Vec<f32> {
-	let n = input.len();
-	let mut output = vec![0.0f32; n];
-	match window_type {
-		"hann" => {
-			for (i, &x) in input.iter().enumerate() {
-				let w = 0.5 * (1.0 - (2.0 * PI * i as f32 / (n as f32 - 1.0)).cos());
-				output[i] = x * w;
-			}
-		}
-		"hamming" => {
-			for (i, &x) in input.iter().enumerate() {
-				let w = 0.54 - 0.46 * (2.0 * PI * i as f32 / (n as f32 - 1.0)).cos();
-				output[i] = x * w;
-			}
-		}
-		"blackman" => {
-			for (i, &x) in input.iter().enumerate() {
-				let w = 0.42 - 0.5 * (2.0 * PI * i as f32 / (n as f32 - 1.0)).cos() + 0.08 * (4.0 * PI * i as f32 / (n as f32 - 1.0)).cos();
-				output[i] = x * w;
-			}
-		}
-		_ => output.copy_from_slice(input), // No window
-	}
-	output
+    let n = input.len();
+    if input.iter().any(|v| !v.is_finite()) {
+        panic!("apply_window: input contains non-finite values");
+    }
+    let mut output = vec![0.0f32; n];
+    let denom = (n as f32 - 1.0).max(1.0);
+    match window_type {
+        "hann" => {
+            for (i, &x) in input.iter().enumerate() {
+                let phase = TWO_PI * i as f32 / denom;
+                let w = HANN_A0 - HANN_A1 * phase.cos();
+                output[i] = x * w;
+            }
+        }
+        "hamming" => {
+            for (i, &x) in input.iter().enumerate() {
+                let phase = TWO_PI * i as f32 / denom;
+                let w = HAMMING_ALPHA - HAMMING_BETA * phase.cos();
+                output[i] = x * w;
+            }
+        }
+        "blackman" => {
+            for (i, &x) in input.iter().enumerate() {
+                let phase = TWO_PI * i as f32 / denom;
+                let w = BLACKMAN_A0 - BLACKMAN_A1 * phase.cos() + BLACKMAN_A2 * (2.0 * phase).cos();
+                output[i] = x * w;
+            }
+        }
+        _ => output.copy_from_slice(input), // No window
+    }
+    output
 }
 
 /// Compute STFT frame: window + FFT + magnitude. What: Complete STFT pipeline in WASM.
 /// Why: Single call reduces JS↔WASM boundary crossings for performance.
 #[wasm_bindgen]
 pub fn stft_frame(input: &[f32], window_type: &str, reference: f32) -> Vec<f32> {
-	let windowed = apply_window(input, window_type);
-	magnitude_dbfs(&windowed, reference)
+    let windowed = apply_window(input, window_type);
+    magnitude_dbfs(&windowed, reference)
 }
 
 /// Compute magnitude spectrum in dBFS from a real block. Windowing is expected to be done by caller.
 #[wasm_bindgen]
 pub fn magnitude_dbfs(input: &[f32], reference: f32) -> Vec<f32> {
-	let spec = fft_real(input);
-	let mut mags = Vec::with_capacity(spec.len() / 2);
-	let mut i = 0usize;
-	let safe_ref = reference.max(1e-12);
-	while i + 1 < spec.len() {
-		let re = spec[i];
-		let im = spec[i + 1];
-		let mag = (re * re + im * im).sqrt();
-		let db = 20.0 * (mag / safe_ref).log10();
-		mags.push(db);
-		i += 2;
-	}
-	mags
+    if input.iter().any(|v| !v.is_finite()) {
+        panic!("magnitude_dbfs: input contains non-finite values");
+    }
+    let spec = fft_real(input);
+    let mut mags = Vec::with_capacity(spec.len() / 2);
+    let mut i = 0usize;
+    let safe_ref = reference.max(EPSILON);
+    while i + 1 < spec.len() {
+        let re = spec[i];
+        let im = spec[i + 1];
+        let mag = (re * re + im * im).sqrt();
+        let db = DB_SCALE * (mag / safe_ref).log10();
+        mags.push(db);
+        i += 2;
+    }
+    mags
 }
 
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// Tolerance for floating point comparisons in tests.
+    const TOLERANCE: f32 = 1e-3;
+
+    /// Size of the test signal used for performance comparisons.
+    const PERF_SIZE: usize = 512;
+
+    /// Naive \(O(n^2)\) FFT used as a correctness reference.
+    fn reference_fft(input: &[f32]) -> Vec<f32> {
+        let n = input.len();
+        let mut output = vec![0.0f32; 2 * n];
+        for k in 0..n {
+            let mut re = 0.0f32;
+            let mut im = 0.0f32;
+            for (i, &x) in input.iter().enumerate() {
+                let angle = -TWO_PI * k as f32 * i as f32 / n as f32;
+                re += x * angle.cos();
+                im += x * angle.sin();
+            }
+            output[2 * k] = re;
+            output[2 * k + 1] = im;
+        }
+        output
+    }
+
+    /// Ensure the optimized FFT matches the reference implementation.
+    #[test]
+    fn fft_matches_reference() {
+        let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let expected = reference_fft(&data);
+        let result = fft_real(&data);
+        for (a, b) in result.iter().zip(expected.iter()) {
+            assert!((a - b).abs() < TOLERANCE, "{} vs {}", a, b);
+        }
+    }
+
+    /// Verify that the optimized FFT is faster than the naive reference.
+    #[test]
+    fn fft_is_faster_than_reference() {
+        let data: Vec<f32> = (0..PERF_SIZE).map(|i| (i as f32).sin()).collect();
+        let start = Instant::now();
+        let _ = reference_fft(&data);
+        let ref_time = start.elapsed();
+
+        let start = Instant::now();
+        let _ = fft_real(&data);
+        let opt_time = start.elapsed();
+
+        assert!(
+            opt_time < ref_time,
+            "optimized {:?} >= reference {:?}",
+            opt_time,
+            ref_time
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- replace slow naive FFT with rustfft for real-to-complex transforms
- refactor windowing and magnitude calculations with named constants and input validation
- add unit tests comparing against a reference FFT and asserting performance improvement

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ed5294c8832b886d656b270b7191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Refactor
  - Replaced internal FFT with a rustfft-based implementation for improved performance and reliability.
  - Enhanced windowing (Hann, Hamming, Blackman) and magnitude (dBFS) calculations with stricter input validation.
- Bug Fixes
  - Improved numerical stability to reduce NaNs/Infs and ensure consistent dB scaling.
- Documentation
  - Expanded inline documentation for FFT, windowing, and magnitude computations.
- Tests
  - Added correctness and performance tests for FFT and related math.
- Chores
  - Updated dependency to rustfft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->