### PR TITLE
Ensure dev-playground rebuilds from a clean state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ dev: ## Start playground development server
 	@echo "🎮 Starting playground development server..."
 	npx -y pnpm@9.0.0 dev:playground
 
-dev-playground: ## Start playground development server (alias for dev)
+dev-playground: ## Clean, build (including WASM), then start playground server
+	$(MAKE) clean
+	$(MAKE) wasm
+	$(MAKE) build
 	$(MAKE) dev
 
 dev-shell: ## Start shell app development server (if implemented)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ make setup
 # Start the playground
 make dev
 
+# Clean, rebuild (including WASM), and start the playground
+make dev-playground
+
 # Build all packages
 make build
 


### PR DESCRIPTION
## Summary
- Rework `dev-playground` to clean, rebuild (including WASM), then launch the playground server
- Document the new `make dev-playground` workflow in the README

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make dev-playground` *(fails: ENOENT no such file or directory '/workspace/spectrogram/web/packages/viewer/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a6fb2abff8832bb2f1076f97bf97aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced dev-playground command to clean, build (including WASM), and then start the playground server for a fresh, reliable setup.
- Documentation
  - Added usage instructions for the dev-playground command, outlining the updated workflow and how to run it.
- Chores
  - Streamlined local development flow by replacing the simple alias with a pre-build sequence before launching the playground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->