### PR TITLE
refactor: load local wasm pkg and fix interval typing

### DIFF
--- a/web/packages/viewer/src/index.tsx
+++ b/web/packages/viewer/src/index.tsx
@@ -45,6 +45,8 @@ const MIN_FREQ_START_HZ = 0;
 const MIN_FREQ_STEP_HZ = 1e-12;
 /** Default display time window in seconds. */
 const DEFAULT_TIME_WINDOW_SEC = 10;
+/** Default duration in seconds for synthetic data generation. */
+const DEFAULT_DATA_DURATION_SECONDS = 30;
 
 /**
  * Validate incoming spectrogram metadata and fail fast on invalid values.
@@ -157,7 +159,11 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
 }) => {
   const canvasRef = React.useRef<HTMLDivElement>(null);
   const ringBufferRef = React.useRef<SpectroRingBuffer | null>(null);
-  const dataIntervalRef = React.useRef<number | null>(null);
+  /**
+   * Handle to the interval generating synthetic data.
+   * Why: typed as ReturnType of setInterval to support both browser and Node environments.
+   */
+  const dataIntervalRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
   const [currentConfig, setCurrentConfig] = React.useState<SpectroConfig>({
     view: '2d-heatmap',
     width: 800,
@@ -170,7 +176,7 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
     showGrid: true,
     background: '#111',
     dataType: 'realistic',
-    dataDuration: 30,
+    dataDuration: DEFAULT_DATA_DURATION_SECONDS,
     autoGenerate: true,
     ...config
   });
@@ -265,7 +271,7 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
       if (!ringBufferRef.current) return;
 
       const dataType = type || currentConfig.dataType || 'realistic';
-      const duration = currentConfig.dataDuration ?? 30;
+      const duration = currentConfig.dataDuration ?? DEFAULT_DATA_DURATION_SECONDS;
       
       try {
         let frames: Array<{ bins: Float32Array; timestamp: number }> = [];
@@ -333,7 +339,7 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
     // Set up periodic generation
     dataIntervalRef.current = setInterval(() => {
       apiRef.current.generateData();
-    }, (currentConfig.dataDuration ?? 30) * 1000);
+    }, (currentConfig.dataDuration ?? DEFAULT_DATA_DURATION_SECONDS) * 1000);
 
     return () => {
       if (dataIntervalRef.current) {

--- a/web/packages/wasm-bindings/package.json
+++ b/web/packages/wasm-bindings/package.json
@@ -7,11 +7,10 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "pnpm run build:wasm && tsup",
+    "build": "pnpm run build:wasm && tsup && cp -r pkg dist/pkg",
     "typecheck": "tsc -p tsconfig.json",
     "test": "pnpm build:wasm && c8 -r text tsx test/wasm-bindings.test.ts",
-    "build:wasm": "wasm-pack build ../../crates/dsp_core --out-dir pkg --target web --release",
-    "typecheck": "tsc -p tsconfig.json",
+    "build:wasm": "wasm-pack build ../../crates/dsp_core --out-dir ../../packages/wasm-bindings/pkg --target web --release",
     "test:unit": "echo 'no unit tests configured'",
     "lint": "echo 'no lint configured'",
     "format": "echo 'no format configured'"

--- a/web/packages/wasm-bindings/tsup.config.ts
+++ b/web/packages/wasm-bindings/tsup.config.ts
@@ -6,9 +6,5 @@ export default defineConfig({
   dts: true,
   splitting: false,
   sourcemap: true,
-  clean: true,
-  loader: {
-    '.wasm': 'copy'
-  },
-  external: ['../../../crates/dsp_core/pkg/spectro_dsp_bg.wasm']
+  clean: true
 });


### PR DESCRIPTION
## Summary
- load wasm-bindgen output from local pkg directory
- copy generated pkg into library distribution bundle
- type-safe interval handle and explicit duration constant in viewer

## Testing
- `pnpm --filter @spectro/wasm-bindings lint`
- `pnpm --filter @spectro/wasm-bindings format`
- `pnpm --filter @spectro/wasm-bindings typecheck`
- `pnpm --filter @spectro/wasm-bindings build`
- `pnpm --filter @spectro/wasm-bindings test`
- `pnpm --filter @spectro/viewer lint`
- `pnpm --filter @spectro/viewer format`
- `pnpm --filter @spectro/viewer typecheck` *(fails: Cannot find type definition file 'offscreencanvas', BufferSource errors, missing test globals)*
- `pnpm --filter @spectro/viewer build`
- `pnpm --filter @spectro/viewer test`
- `pnpm --filter @spectro/playground build`


------
https://chatgpt.com/codex/tasks/task_e_68a6fcf00c80832bb9d89b9c79490475