### PR TITLE
feat: ensure wasm served with correct mime type

### DIFF
--- a/web/apps/playground/vite.config.ts
+++ b/web/apps/playground/vite.config.ts
@@ -2,13 +2,38 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
+/**
+ * Dev server port.
+ * Why: avoid magic numbers for clarity and maintainability.
+ */
+const DEV_SERVER_PORT = 5175
+
+/**
+ * MIME type served for WebAssembly binaries.
+ * Why: ensure browsers can stream WASM via `instantiateStreaming`.
+ */
+const WASM_CONTENT_TYPE = 'application/wasm'
+
 export default defineConfig({
   plugins: [react()],
-  server: { port: 5175 },
+  server: {
+    port: DEV_SERVER_PORT,
+    /**
+     * Explicit MIME mapping so `.wasm` files are served correctly.
+     * How: Vite dev server will attach the proper `Content-Type` header.
+     */
+    mimeTypes: { '.wasm': WASM_CONTENT_TYPE }
+  },
   resolve: {
     alias: {
-      '@spectro/wasm-bindings': resolve(__dirname, '../../packages/wasm-bindings/dist/index.js'),
-      '@spectro/viewer': resolve(__dirname, '../../packages/viewer/dist/index.js')
+      '@spectro/wasm-bindings': resolve(
+        __dirname,
+        '../../packages/wasm-bindings/dist/index.js'
+      ),
+      '@spectro/viewer': resolve(
+        __dirname,
+        '../../packages/viewer/dist/index.js'
+      )
     }
   },
   optimizeDeps: {

--- a/web/packages/wasm-bindings/test/wasm-bindings.test.ts
+++ b/web/packages/wasm-bindings/test/wasm-bindings.test.ts
@@ -2,30 +2,64 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { initWasm, fftReal, applyWindow, stftFrame, magnitudeDbfs } from '../src/index.ts';
+import {
+  initWasm,
+  fftReal,
+  applyWindow,
+  stftFrame,
+  magnitudeDbfs
+} from '../src/index.ts';
+
+/**
+ * Expected MIME type for WASM responses.
+ * Why: ensures `instantiateStreaming` can compile without fallback.
+ */
+const WASM_CONTENT_TYPE = 'application/wasm';
+
+/**
+ * Deterministic sample data for DSP routines.
+ * How: short alternating values exercise positive/negative paths.
+ */
+const TEST_SIGNAL_VALUES = [1, -1, 0.5, -0.5] as const;
 
 // Allow wasm-pack's browser loader to fetch local files in Node.
+/** Preserve original fetch implementation for cleanup. */
 const realFetch = globalThis.fetch;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(globalThis.fetch as any) = async (input: any, init?: any): Promise<Response> => {
+;(globalThis.fetch as any) = async (input: any, init?: any): Promise<Response> => {
   if (typeof input === 'string' && input.startsWith('file://')) {
     const data = await readFile(fileURLToPath(input));
-    return new Response(data, { headers: { 'Content-Type': 'application/wasm' } });
+    return new Response(data, { headers: { 'Content-Type': WASM_CONTENT_TYPE } });
   }
   if (input instanceof URL && input.protocol === 'file:') {
     const data = await readFile(fileURLToPath(input));
-    return new Response(data, { headers: { 'Content-Type': 'application/wasm' } });
+    return new Response(data, { headers: { 'Content-Type': WASM_CONTENT_TYPE } });
   }
   return realFetch(input, init);
 };
 
+/** Flag indicating whether streaming compilation was exercised. */
+let streamingUsed = false;
+/** Preserve original instantiateStreaming to restore after test. */
+const realInstantiateStreaming = WebAssembly.instantiateStreaming;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(WebAssembly as any).instantiateStreaming = async (
+  source: Promise<Response> | Response,
+  importObject?: Record<string, unknown>
+) => {
+  streamingUsed = true;
+  return realInstantiateStreaming(source, importObject);
+};
+
 // Utility to create a simple test buffer
 function makeInput(): Float32Array {
-  return new Float32Array([1, -1, 0.5, -0.5]);
+  return new Float32Array(TEST_SIGNAL_VALUES);
 }
 
 test('WASM bindings execute and validate inputs', async () => {
   await initWasm();
+  assert.ok(streamingUsed, 'instantiateStreaming should be used for init');
+  WebAssembly.instantiateStreaming = realInstantiateStreaming;
 
   const fft = await fftReal(makeInput());
   assert.equal(fft.length, 8);


### PR DESCRIPTION
## Summary
- serve `.wasm` with `application/wasm` in playground dev server
- test WASM init via `WebAssembly.instantiateStreaming`

## Testing
- `pnpm --filter @spectro/wasm-bindings test` *(fails: wasm-pack: not found)*
- `pnpm dev:playground` *(started but missing WASM artifacts for verification)*

------
https://chatgpt.com/codex/tasks/task_e_68a704e483c8832b93ed72c73da6e23e