### PR TITLE
Use ring buffer stats for heatmap texture sizing

### DIFF
--- a/web/packages/viewer/src/renderers/__tests__/heatmap-2d.test.ts
+++ b/web/packages/viewer/src/renderers/__tests__/heatmap-2d.test.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import { describe, it, expect, vi } from 'vitest';
+
+import { textureSizeFromRingBuffer } from '../heatmap-2d';
+import { SpectroRingBuffer } from '../../core/ring-buffer';
+
+// Mock WASM bindings to avoid requiring compiled artifacts during tests
+vi.mock('@spectro/wasm-bindings', () => ({}), { virtual: true });
+
+/**
+ * Helper to create a ring buffer of the specified dimensions.
+ * What: Instantiates SpectroRingBuffer with a dummy WebGL context.
+ * Why: Allows CPU-side testing without actual WebGL.
+ */
+function makeRingBuffer(binCount: number, maxRows: number): SpectroRingBuffer {
+  const gl = {} as unknown as WebGLRenderingContext;
+  return new SpectroRingBuffer(gl, { binCount, maxRows, format: 'R32F', linearFilter: false });
+}
+
+describe('textureSizeFromRingBuffer', () => {
+  it('writes buffer stats into the provided vector', () => {
+    const cases = [
+      { bins: 16, rows: 8 },
+      { bins: 32, rows: 16 }
+    ];
+
+    for (const { bins, rows } of cases) {
+      const rb = makeRingBuffer(bins, rows);
+      const target = new THREE.Vector2();
+      const result = textureSizeFromRingBuffer(rb, target);
+      expect(result).toBe(target);
+      expect(target.x).toBe(bins);
+      expect(target.y).toBe(rows);
+    }
+  });
+
+  it('throws on invalid statistics', () => {
+    const badRing = { getStats: () => ({ binCount: 0, maxRows: 0 }) } as SpectroRingBuffer;
+    expect(() => textureSizeFromRingBuffer(badRing)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- derive heatmap texture size from ring-buffer statistics
- replace magic numbers with well-named constants
- add unit tests for texture size calculation

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm --filter @spectro/viewer test:unit`
- `pnpm --filter @spectro/viewer typecheck` *(fails: Cannot find type definition file for 'offscreencanvas' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ca90a18832bbc5e3ad91289393c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional grid overlay to Heatmap 2D with configurable guide lines.
  - Standardized LUT, texture, and geometry sizing for consistent visuals.

- Refactor
  - Centralized sizing/styling constants and simplified mesh setup.
  - Texture size now derives directly from incoming data.
  - Breaking: Heatmap2D now requires a ring buffer prop.

- Tests
  - Added unit tests covering texture sizing and invalid data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->