### PR TITLE
Refactor music signal generator and add tests

### DIFF
--- a/web/packages/viewer/src/utils/__tests__/generate-music-signal.test.ts
+++ b/web/packages/viewer/src/utils/__tests__/generate-music-signal.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for generateMusicSignal.
+ * What: Verifies signal length, amplitude range, and input validation.
+ * Why: Ensures music signal generation is deterministic and safe.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const DataGenerator = await import('../data-generator');
+
+// Shorthand reference for function under test
+const { generateMusicSignal } = DataGenerator;
+
+/** Number of samples to generate for testing. */
+const TEST_LENGTH = 48;
+/** Sample rate for testing, in hertz. */
+const TEST_SAMPLE_RATE = 48000;
+
+describe('generateMusicSignal', () => {
+  let mathRandomSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Make noise deterministic for assertions
+    mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    mathRandomSpy.mockRestore();
+  });
+
+  it('produces signal of requested length within [-1,1]', () => {
+    const result = generateMusicSignal(TEST_LENGTH, TEST_SAMPLE_RATE);
+    expect(result.length).toBe(TEST_LENGTH);
+    Array.from(result).forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(-1);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('throws on non-positive length', () => {
+    expect(() => generateMusicSignal(0, TEST_SAMPLE_RATE)).toThrow(
+      'length must be positive'
+    );
+  });
+
+  it('throws on non-positive sample rate', () => {
+    expect(() => generateMusicSignal(TEST_LENGTH, 0)).toThrow(
+      'sampleRate must be positive'
+    );
+  });
+});

--- a/web/packages/viewer/vitest.config.ts
+++ b/web/packages/viewer/vitest.config.ts
@@ -22,7 +22,12 @@ export default defineConfig({
     globals: true,
     coverage: {
       reporter: ['text', 'html'],
-      include: ['src/index.tsx', 'src/core/ring-buffer.ts'],
+      include: [
+        'src/index.tsx',
+        'src/core/ring-buffer.ts',
+        // Include utility generators to ensure they maintain test coverage
+        'src/utils/data-generator.ts',
+      ],
       lines: 50,
       functions: 50,
       statements: 50,


### PR DESCRIPTION
## Summary
- replace magic numbers in music signal generator with named constants and input validation
- include utils in coverage config
- add unit tests for music signal generator

## Testing
- `pnpm -r --filter './web/packages/*' run format`
- `pnpm -r --filter './web/packages/*' run lint`
- `pnpm --filter @spectro/viewer exec vitest run src/utils/__tests__/generate-music-signal.test.ts`
- `pnpm -r --filter './web/packages/*' run test` *(fails: The symbol "offset" has already been declared in ring-buffer.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a718ce8110832b9dd86b50e3914ab1