### PR TITLE
Validate test signal amplitude inputs

### DIFF
--- a/web/packages/viewer/src/utils/__tests__/generate-test-signal.test.ts
+++ b/web/packages/viewer/src/utils/__tests__/generate-test-signal.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for generateTestSignal validation.
+ * What: Ensures generateTestSignal rejects invalid configuration parameters.
+ * Why: Guards against malformed inputs that could corrupt synthetic audio.
+ */
+import { describe, expect, it } from 'vitest';
+
+const DataGenerator = await import('../data-generator');
+
+/** Shorthand reference for function under test. */
+const { generateTestSignal } = DataGenerator;
+
+/** Number of samples used in validation tests. */
+const TEST_LENGTH = 8;
+/** Sample rate in hertz used for validation tests. */
+const TEST_SAMPLE_RATE = 48_000;
+/** Single frequency used to produce deterministic validation signals. */
+const TEST_FREQUENCIES = [440];
+/** Error message thrown for invalid amplitude values. */
+const AMP_ERROR_MESSAGE =
+  'amplitudes must be finite numbers within [0, 1]';
+
+describe('generateTestSignal validation', () => {
+  it('throws when frequencies and amplitudes lengths differ', () => {
+    expect(() =>
+      generateTestSignal(TEST_LENGTH, TEST_SAMPLE_RATE, TEST_FREQUENCIES, [])
+    ).toThrow('frequencies and amplitudes arrays must have the same length');
+  });
+
+  it.each([
+    /** Negative amplitude below lower bound. */
+    { amplitudes: [-0.1] },
+    /** Amplitude exceeding MAX_AMPLITUDE. */
+    { amplitudes: [1.1] },
+    /** Amplitude that is not a finite number. */
+    { amplitudes: [Number.NaN] }
+  ])('throws on invalid amplitudes: %o', ({ amplitudes }) => {
+    expect(() =>
+      generateTestSignal(
+        TEST_LENGTH,
+        TEST_SAMPLE_RATE,
+        TEST_FREQUENCIES,
+        amplitudes
+      )
+    ).toThrow(AMP_ERROR_MESSAGE);
+  });
+});
+

--- a/web/packages/viewer/src/utils/data-generator.ts
+++ b/web/packages/viewer/src/utils/data-generator.ts
@@ -126,17 +126,34 @@ export const SIGNAL_PRESETS: Record<SignalType, SignalTypeConfig> = {
  * Generate a realistic test signal with multiple frequencies and noise.
  * What: Creates a complex audio signal with multiple components
  * Why: Provides realistic data for testing spectrogram visualization
+ * How: Validates inputs then synthesizes summed sine waves with optional
+ *      modulation, harmonics, and noise.
  */
 export function generateTestSignal(
-  length: number, 
-  sampleRate: number, 
-  frequencies: number[], 
+  length: number,
+  sampleRate: number,
+  frequencies: number[],
   amplitudes: number[],
   noiseLevel: number = 0.05,
   modulation: boolean = false,
   harmonics: boolean = false,
   timeVarying: boolean = false
 ): Float32Array {
+  // Validate array lengths and amplitude ranges to avoid runtime errors
+  if (frequencies.length !== amplitudes.length) {
+    throw new Error(
+      'frequencies and amplitudes arrays must have the same length'
+    );
+  }
+
+  for (const amp of amplitudes) {
+    if (!Number.isFinite(amp) || amp < 0 || amp > MAX_AMPLITUDE) {
+      throw new Error(
+        `amplitudes must be finite numbers within [0, ${MAX_AMPLITUDE}]`
+      );
+    }
+  }
+
   const signal = new Float32Array(length);
   const timeStep = 1.0 / sampleRate;
   


### PR DESCRIPTION
## Summary
- validate matching frequency and amplitude arrays and enforce amplitude bounds in `generateTestSignal`
- add unit tests covering mismatched array lengths and invalid amplitude values

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for 'offscreencanvas', duplicate identifiers in ring-buffer, etc.)*
- `pnpm --filter @spectro/viewer test` *(fails: transform error in ring-buffer test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68a721674628832bb79d57a2c50fde0a