### PR TITLE
refactor(viewer): centralize frame count and mix amplitudes

### DIFF
--- a/web/packages/viewer/tsconfig.json
+++ b/web/packages/viewer/tsconfig.json
@@ -7,7 +7,9 @@
     "moduleResolution": "bundler",
     "target": "ES2020",
     "lib": ["ES2020", "DOM"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    // Include Vitest global types so test files type-check correctly.
+    "types": ["vitest/globals"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- avoid repeated `Math.floor(duration * 10)` by precomputing a frame count based on a new `SYNTHETIC_FRAME_RATE`
- replace magic amplitude numbers in mixed-signal generation with named constants and documentation
- add Vitest global typings to ensure tests type-check

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test` *(fails: wasm-pack not found)*
- `pnpm --filter @spectro/viewer test`
- `pnpm --filter @spectro/viewer typecheck` *(fails: missing type definitions and WebGL types)*

------
https://chatgpt.com/codex/tasks/task_e_68a7256f83dc832ba7c1e9b4b2fb1108