### PR TITLE
Guard grid bounds in heatmap renderer and add tests

### DIFF
--- a/web/packages/viewer/src/renderers/__tests__/heatmap-2d.test.ts
+++ b/web/packages/viewer/src/renderers/__tests__/heatmap-2d.test.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { describe, it, expect, vi } from 'vitest';
 
-import { textureSizeFromRingBuffer } from '../heatmap-2d';
+import { textureSizeFromRingBuffer, generateGridLineVertices } from '../heatmap-2d';
 import { SpectroRingBuffer } from '../../core/ring-buffer';
 
 // Mock WASM bindings to avoid requiring compiled artifacts during tests
@@ -43,5 +43,34 @@ describe('textureSizeFromRingBuffer', () => {
   it('throws on invalid statistics', () => {
     const badRing = { getStats: () => ({ binCount: 0, maxRows: 0 }) } as SpectroRingBuffer;
     expect(() => textureSizeFromRingBuffer(badRing)).toThrow();
+  });
+});
+
+/**
+ * Tests for {@link generateGridLineVertices}.
+ * What: Ensures geometry generation validates bounds and counts.
+ * Why: Guarantees fail-fast behavior on invalid parameters.
+ */
+describe('generateGridLineVertices', () => {
+  /** Line count used for test grids. */
+  const TEST_LINE_COUNT = 3;
+  /** Lower bound for valid grid generation. */
+  const TEST_MIN = 0;
+  /** Upper bound for valid grid generation. */
+  const TEST_MAX = 1;
+
+  it('throws when max is not greater than min', () => {
+    expect(() => generateGridLineVertices(TEST_LINE_COUNT, TEST_MAX, TEST_MAX)).toThrow();
+    expect(() => generateGridLineVertices(TEST_LINE_COUNT, TEST_MAX, TEST_MIN)).toThrow();
+  });
+
+  it('generates expected line count for valid bounds', () => {
+    const { horizontal, vertical } = generateGridLineVertices(
+      TEST_LINE_COUNT,
+      TEST_MIN,
+      TEST_MAX
+    );
+    expect(horizontal).toHaveLength(TEST_LINE_COUNT);
+    expect(vertical).toHaveLength(TEST_LINE_COUNT);
   });
 });

--- a/web/packages/viewer/src/renderers/heatmap-2d.tsx
+++ b/web/packages/viewer/src/renderers/heatmap-2d.tsx
@@ -19,6 +19,8 @@ const LUT_HEIGHT = 1;
 const PLANE_SIZE = 2;
 /** Number of grid lines to draw per axis in the overlay. */
 const GRID_LINE_COUNT = 10;
+/** Minimum number of grid lines allowed for valid geometry generation. */
+const GRID_LINE_MIN_COUNT = 2;
 /** Color used for grid overlay lines. */
 const GRID_LINE_COLOR = '#333';
 /** Transparency applied to grid overlay lines. */
@@ -32,15 +34,20 @@ const GRID_MAX = 1;
  * Generate vertex arrays for the grid overlay.
  * What: Precomputes coordinates for horizontal and vertical grid lines as {@link Float32Array}s.
  * Why: Avoids per-render allocations and ensures stable geometry data.
- * How: Evenly interpolates positions between {@link GRID_MIN} and {@link GRID_MAX} for the given count.
+ * How: Validates bounds and line count, then interpolates positions between `min` and `max`.
  */
 export function generateGridLineVertices(
   lineCount: number = GRID_LINE_COUNT,
   min: number = GRID_MIN,
   max: number = GRID_MAX
 ): { horizontal: Float32Array[]; vertical: Float32Array[] } {
-  if (lineCount < 2) {
-    throw new Error(`lineCount must be at least 2; got ${lineCount}`);
+  if (lineCount < GRID_LINE_MIN_COUNT) {
+    throw new Error(
+      `lineCount must be at least ${GRID_LINE_MIN_COUNT}; got ${lineCount}`
+    );
+  }
+  if (max <= min) {
+    throw new Error(`max must be greater than min; got min=${min}, max=${max}`);
   }
   const horizontal: Float32Array[] = [];
   const vertical: Float32Array[] = [];


### PR DESCRIPTION
## Summary
- prevent invalid grid bounds in `generateGridLineVertices`
- test grid vertex generation for invalid bounds

## Testing
- `pnpm --filter @spectro/viewer lint`
- `pnpm --filter @spectro/viewer format`
- `pnpm --filter @spectro/viewer test`
- `pnpm --filter @spectro/viewer typecheck` *(fails: Cannot find type definition file for 'offscreencanvas', other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7257fee80832bbeffb6f48e48cadd