### PR TITLE
feat(viewer): validate legend dB range

### DIFF
--- a/web/packages/viewer/src/ui/legend.test.tsx
+++ b/web/packages/viewer/src/ui/legend.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { Legend } from './legend';
+
+/** Default palette used across tests. */
+const TEST_PALETTE = 'viridis';
+
+/**
+ * Provide a minimal canvas context stub to satisfy rendering without requiring
+ * the optional canvas package in tests.
+ */
+beforeAll(() => {
+  // Silence expected React errors during failed renders
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  HTMLCanvasElement.prototype.getContext = () => null as any;
+});
+
+describe('Legend dB range validation', () => {
+  /**
+   * What: Ensure valid dB ranges render without error.
+   * Why: Correct ranges should not trigger validation.
+   */
+  it('renders for valid dB range', () => {
+    expect(() =>
+      render(<Legend palette={TEST_PALETTE} dbFloor={0} dbCeiling={10} />)
+    ).not.toThrow();
+  });
+
+  /**
+   * What: Verify equal floor and ceiling are rejected.
+   * Why: Zero-span ranges make the legend meaningless.
+   */
+  it('throws for equal dB floor and ceiling', () => {
+    expect(() =>
+      render(<Legend palette={TEST_PALETTE} dbFloor={5} dbCeiling={5} />)
+    ).toThrow(/dbCeiling/);
+  });
+
+  /**
+   * What: Verify inverted ranges are rejected.
+   * Why: Inverted ranges indicate caller bugs and should fail fast.
+   */
+  it('throws for inverted dB range', () => {
+    expect(() =>
+      render(<Legend palette={TEST_PALETTE} dbFloor={10} dbCeiling={0} />)
+    ).toThrow(/dbCeiling/);
+  });
+});

--- a/web/packages/viewer/src/ui/legend.tsx
+++ b/web/packages/viewer/src/ui/legend.tsx
@@ -7,6 +7,33 @@
 import * as React from 'react';
 import { generateLUT, type Palette } from '../palettes';
 
+/** Default legend width in pixels. */
+const DEFAULT_WIDTH_PX = 30;
+/** Default legend height in pixels. */
+const DEFAULT_HEIGHT_PX = 200;
+/** Number of entries in the color lookup table. */
+const LUT_ENTRIES = 256;
+/** Number of color components (RGBA) per lookup table entry. */
+const COLOR_COMPONENTS = 4;
+/** Number of dB labels displayed along the legend. */
+const LABEL_COUNT = 5;
+/** Length of tick marks in pixels. */
+const TICK_LENGTH_PX = 5;
+/** Horizontal offset for dB label text in pixels. */
+const LABEL_X_OFFSET_PX = 8;
+/** Vertical offset for dB label text in pixels. */
+const LABEL_Y_OFFSET_PX = 4;
+/** Font specification for dB labels. */
+const LABEL_FONT = '12px monospace';
+/** Stroke color for legend border and tick marks. */
+const STROKE_COLOR = '#666';
+/** Fill color for dB label text. */
+const LABEL_COLOR = '#fff';
+/** Width of lines used for borders and ticks in pixels. */
+const LINE_WIDTH_PX = 1;
+/** Maximum value for an 8-bit color channel. */
+const COLOR_MAX = 255;
+
 /** Props for the legend component. */
 interface LegendProps {
   /** Color palette for the legend. */
@@ -35,14 +62,21 @@ export const Legend: React.FC<LegendProps> = ({
   paletteReverse = false,
   dbFloor,
   dbCeiling,
-  width = 30,
-  height = 200,
+  width = DEFAULT_WIDTH_PX,
+  height = DEFAULT_HEIGHT_PX,
   className
 }) => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
 
   // Draw legend on canvas
   React.useEffect(() => {
+    // Validate dB range to avoid inverted or zero-span legends
+    if (dbCeiling <= dbFloor) {
+      throw new RangeError(
+        `Legend requires dbCeiling (${dbCeiling}) to be greater than dbFloor (${dbFloor}).`
+      );
+    }
+
     const canvas = canvasRef.current;
     if (!canvas) return;
 
@@ -54,18 +88,21 @@ export const Legend: React.FC<LegendProps> = ({
     canvas.height = height;
 
     // Generate color LUT
-    const lut = generateLUT(palette);
+    const lut = generateLUT(palette, LUT_ENTRIES);
     const gradient = ctx.createLinearGradient(0, height, 0, 0);
 
     // Create gradient stops
-    for (let i = 0; i < 256; i++) {
-      const t = i / 255;
-      const colorIndex = paletteReverse ? 255 - i : i;
-      const r = lut[colorIndex * 4] / 255;
-      const g = lut[colorIndex * 4 + 1] / 255;
-      const b = lut[colorIndex * 4 + 2] / 255;
-      
-      gradient.addColorStop(t, `rgb(${r * 255}, ${g * 255}, ${b * 255})`);
+    for (let i = 0; i < LUT_ENTRIES; i++) {
+      const t = i / (LUT_ENTRIES - 1);
+      const colorIndex = paletteReverse ? LUT_ENTRIES - 1 - i : i;
+      const r = lut[colorIndex * COLOR_COMPONENTS] / COLOR_MAX;
+      const g = lut[colorIndex * COLOR_COMPONENTS + 1] / COLOR_MAX;
+      const b = lut[colorIndex * COLOR_COMPONENTS + 2] / COLOR_MAX;
+
+      gradient.addColorStop(
+        t,
+        `rgb(${r * COLOR_MAX}, ${g * COLOR_MAX}, ${b * COLOR_MAX})`
+      );
     }
 
     // Fill gradient
@@ -73,31 +110,34 @@ export const Legend: React.FC<LegendProps> = ({
     ctx.fillRect(0, 0, width, height);
 
     // Add border
-    ctx.strokeStyle = '#666';
-    ctx.lineWidth = 1;
+    ctx.strokeStyle = STROKE_COLOR;
+    ctx.lineWidth = LINE_WIDTH_PX;
     ctx.strokeRect(0, 0, width, height);
 
     // Add dB labels
-    ctx.fillStyle = '#fff';
-    ctx.font = '12px monospace';
+    ctx.fillStyle = LABEL_COLOR;
+    ctx.font = LABEL_FONT;
     ctx.textAlign = 'left';
-    
-    const labelCount = 5;
-    for (let i = 0; i <= labelCount; i++) {
-      const t = i / labelCount;
+
+    for (let i = 0; i <= LABEL_COUNT; i++) {
+      const t = i / LABEL_COUNT;
       const db = dbFloor + (dbCeiling - dbFloor) * t;
       const y = height - t * height;
-      
+
       // Draw tick mark
-      ctx.strokeStyle = '#fff';
-      ctx.lineWidth = 1;
+      ctx.strokeStyle = LABEL_COLOR;
+      ctx.lineWidth = LINE_WIDTH_PX;
       ctx.beginPath();
       ctx.moveTo(width, y);
-      ctx.lineTo(width + 5, y);
+      ctx.lineTo(width + TICK_LENGTH_PX, y);
       ctx.stroke();
-      
+
       // Draw label
-      ctx.fillText(`${db.toFixed(0)} dB`, width + 8, y + 4);
+      ctx.fillText(
+        `${db.toFixed(0)} dB`,
+        width + LABEL_X_OFFSET_PX,
+        y + LABEL_Y_OFFSET_PX
+      );
     }
   }, [palette, paletteReverse, dbFloor, dbCeiling, width, height]);
 

--- a/web/packages/viewer/vitest.config.ts
+++ b/web/packages/viewer/vitest.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
         'src/core/ring-buffer.ts',
         // Include utility generators to ensure they maintain test coverage
         'src/utils/data-generator.ts',
+        // Include legend UI to track validation logic
+        'src/ui/legend.tsx',
       ],
       lines: 50,
       functions: 50,


### PR DESCRIPTION
## Summary
- validate legend dB range and eliminate magic numbers
- add tests for valid, equal, and inverted dB ranges

## Testing
- `pnpm -r --filter @spectro/viewer test`

------
https://chatgpt.com/codex/tasks/task_e_68a725502dbc832b8ab943c20e601f45