### PR TITLE
refactor: centralize validation logic with reusable assertions

### DIFF
--- a/web/packages/viewer/src/index.tsx
+++ b/web/packages/viewer/src/index.tsx
@@ -6,14 +6,15 @@ import { Heatmap2D } from './renderers/heatmap-2d';
 import { Legend } from './ui/legend';
 import { DEFAULT_BG } from './constants';
 import {
-  generateRealisticSpectrogramData, 
-  generateSignalByType, 
+  generateRealisticSpectrogramData,
+  generateSignalByType,
   generateMusicSignal,
   generateMixedSignal,
   generateSTFTFrames,
   type SignalType,
-  DEFAULT_CONFIG 
+  DEFAULT_CONFIG
 } from './utils/data-generator';
+import { assertNonEmptyString, assertFiniteAtLeast } from './utils/assert';
 import type { Palette } from './palettes';
 
 // Re-export palette utilities
@@ -62,14 +63,14 @@ const DEFAULT_MAX_ROWS = 512;
  * Why: Prevents subtle bugs or crashes stemming from impossible parameters.
  */
 function validateMeta(meta: SpectroMeta): void {
-  if (!meta.streamId) throw new Error('streamId is required');
-  if (!Number.isFinite(meta.channels) || meta.channels < MIN_CHANNELS) throw new Error('Invalid channel count');
-  if (!Number.isFinite(meta.sampleRateHz) || meta.sampleRateHz < MIN_SAMPLE_RATE_HZ) throw new Error('Invalid sample rate');
-  if (!Number.isFinite(meta.nfft) || meta.nfft < MIN_NFFT) throw new Error('Invalid FFT size');
-  if (!Number.isFinite(meta.hopSize) || meta.hopSize < MIN_HOP_SIZE) throw new Error('Invalid hop size');
-  if (!Number.isFinite(meta.binCount) || meta.binCount < MIN_BIN_COUNT) throw new Error('Invalid bin count');
-  if (!Number.isFinite(meta.freqStartHz) || meta.freqStartHz < MIN_FREQ_START_HZ) throw new Error('Invalid start frequency');
-  if (!Number.isFinite(meta.freqStepHz) || meta.freqStepHz < MIN_FREQ_STEP_HZ) throw new Error('Invalid frequency step');
+  assertNonEmptyString(meta.streamId, 'streamId');
+  assertFiniteAtLeast(meta.channels, MIN_CHANNELS, 'channels');
+  assertFiniteAtLeast(meta.sampleRateHz, MIN_SAMPLE_RATE_HZ, 'sampleRateHz');
+  assertFiniteAtLeast(meta.nfft, MIN_NFFT, 'nfft');
+  assertFiniteAtLeast(meta.hopSize, MIN_HOP_SIZE, 'hopSize');
+  assertFiniteAtLeast(meta.binCount, MIN_BIN_COUNT, 'binCount');
+  assertFiniteAtLeast(meta.freqStartHz, MIN_FREQ_START_HZ, 'freqStartHz');
+  assertFiniteAtLeast(meta.freqStepHz, MIN_FREQ_STEP_HZ, 'freqStepHz');
   if (!(meta.scale === 'dbfs' || meta.scale === 'linear')) throw new Error(`Invalid scale ${meta.scale}`);
   if (meta.freqScale && !(meta.freqScale === 'linear' || meta.freqScale === 'log' || meta.freqScale === 'mel')) {
     throw new Error(`Invalid freqScale ${meta.freqScale}`);

--- a/web/packages/viewer/src/utils/__tests__/assert.test.ts
+++ b/web/packages/viewer/src/utils/__tests__/assert.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for assertion helpers.
+ * What: Verifies that validation utilities accept valid input and reject bad input.
+ * Why: Ensures early failure for malformed parameters throughout the codebase.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertNonEmptyString,
+  assertFiniteNumber,
+  assertPositiveFinite,
+  assertFiniteAtLeast,
+  POSITIVE_MIN
+} from '../assert';
+
+/** Lower bound used in tests for assertFiniteAtLeast. */
+const TEST_MIN = 5;
+
+describe('assertion helpers', () => {
+  it('accepts valid values', () => {
+    expect(() => assertNonEmptyString('ok', 'name')).not.toThrow();
+    expect(() => assertFiniteNumber(1, 'num')).not.toThrow();
+    expect(() => assertPositiveFinite(1, 'pos')).not.toThrow();
+    expect(() => assertFiniteAtLeast(TEST_MIN, TEST_MIN, 'min')).not.toThrow();
+  });
+
+  it.each([['', 'empty'], [null, 'null'], [undefined, 'undefined']])(
+    'assertNonEmptyString rejects %s',
+    value => {
+      expect(() => assertNonEmptyString(value as any, 's')).toThrow(
+        's must be a non-empty string'
+      );
+    }
+  );
+
+  it.each([[Number.NaN], [Number.POSITIVE_INFINITY], [Number.NEGATIVE_INFINITY]])(
+    'assertFiniteNumber rejects %s',
+    value => {
+      expect(() => assertFiniteNumber(value, 'n')).toThrow(
+        'n must be a finite number'
+      );
+    }
+  );
+
+  it.each([[0], [-1]])('assertPositiveFinite rejects %s', value => {
+    expect(() => assertPositiveFinite(value as any, 'p')).toThrow(
+      `p must be > ${POSITIVE_MIN}`
+    );
+  });
+
+  it('assertPositiveFinite rejects non-finite numbers', () => {
+    expect(() => assertPositiveFinite(Number.NaN, 'p')).toThrow(
+      'p must be a finite number'
+    );
+  });
+
+  it('assertFiniteAtLeast enforces inclusive lower bound', () => {
+    expect(() => assertFiniteAtLeast(TEST_MIN - 1, TEST_MIN, 'm')).toThrow(
+      `m must be >= ${TEST_MIN}`
+    );
+  });
+});

--- a/web/packages/viewer/src/utils/assert.ts
+++ b/web/packages/viewer/src/utils/assert.ts
@@ -1,0 +1,75 @@
+/**
+ * Assertion utilities for runtime validation.
+ * What: Provides reusable type guards for strings and numbers.
+ * Why: Centralizes validation logic and eliminates repeated boilerplate.
+ * How: Throws descriptive errors when values violate required constraints.
+ */
+
+/** Exclusive lower bound used when checking for positive values. */
+const POSITIVE_MIN = 0;
+
+/**
+ * Assert that a value is a non-empty string.
+ * @param value - Value to validate.
+ * @param name - Human-readable parameter name for error messages.
+ * @throws {Error} If the value is not a non-empty string.
+ */
+export function assertNonEmptyString(
+  value: unknown,
+  name: string
+): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+}
+
+/**
+ * Assert that a value is a finite number.
+ * @param value - Value to validate.
+ * @param name - Human-readable parameter name for error messages.
+ * @throws {Error} If the value is not a finite number.
+ */
+export function assertFiniteNumber(
+  value: unknown,
+  name: string
+): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number`);
+  }
+}
+
+/**
+ * Assert that a number is finite and greater than zero.
+ * @param value - Value to validate.
+ * @param name - Human-readable parameter name for error messages.
+ * @throws {Error} If the value is not finite or not strictly positive.
+ */
+export function assertPositiveFinite(
+  value: unknown,
+  name: string
+): asserts value is number {
+  assertFiniteNumber(value, name);
+  if (value <= POSITIVE_MIN) {
+    throw new Error(`${name} must be > ${POSITIVE_MIN}`);
+  }
+}
+
+/**
+ * Assert that a number is finite and at least a minimum value.
+ * @param value - Value to validate.
+ * @param min - Inclusive lower bound.
+ * @param name - Human-readable parameter name for error messages.
+ * @throws {Error} If the value is not finite or falls below the bound.
+ */
+export function assertFiniteAtLeast(
+  value: unknown,
+  min: number,
+  name: string
+): asserts value is number {
+  assertFiniteNumber(value, name);
+  if (value < min) {
+    throw new Error(`${name} must be >= ${min}`);
+  }
+}
+
+export { POSITIVE_MIN };


### PR DESCRIPTION
## Summary
- add reusable assertion helpers for strings and numeric bounds
- refactor `validateMeta` to use new helpers
- cover assertion utilities with exhaustive unit tests

## Testing
- `pnpm lint`
- `pnpm --filter @spectro/viewer test`
- `pnpm test` *(fails: wasm-pack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a725568c68832bbfa7f3af1401b012