### PR TITLE
feat: centralize generated fps constant

### DIFF
--- a/web/packages/viewer/src/constants.ts
+++ b/web/packages/viewer/src/constants.ts
@@ -5,3 +5,13 @@
  * How: Import wherever a default background is needed.
  */
 export const DEFAULT_BG = '#111111';
+
+/**
+ * Default frames-per-second for synthetic STFT data generation.
+ * What: Baseline rate at which spectrogram frames are produced when creating
+ * synthetic data.
+ * Why: Avoids hardcoded frame counts and keeps demos and tests in sync.
+ * How: Multiply a duration in seconds by this constant to determine how many
+ * STFT frames to generate.
+ */
+export const DEFAULT_GENERATED_FPS = 10;

--- a/web/packages/viewer/src/index.tsx
+++ b/web/packages/viewer/src/index.tsx
@@ -4,7 +4,7 @@ import type { WebGLRenderer } from 'three';
 import { SpectroRingBuffer } from './core/ring-buffer';
 import { Heatmap2D } from './renderers/heatmap-2d';
 import { Legend } from './ui/legend';
-import { DEFAULT_BG } from './constants';
+import { DEFAULT_BG, DEFAULT_GENERATED_FPS } from './constants';
 import {
   generateRealisticSpectrogramData, 
   generateSignalByType, 
@@ -22,7 +22,7 @@ export { generateLUT, samplePalette, type Palette, type PaletteName, type RGBA }
 // Re-export data generator types
 export { type SignalType } from './utils/data-generator';
 // Re-export shared constants
-export { DEFAULT_BG } from './constants';
+export { DEFAULT_BG, DEFAULT_GENERATED_FPS } from './constants';
 
 /** View modes supported by the spectrogram viewer. */
 export type ViewMode = '2d-heatmap' | '2d-waterfall' | '3d-waterfall' | 'polar' | 'bars' | 'ridge' | 'waveform' | 'mel' | 'chroma';
@@ -330,7 +330,12 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
         } else if (dataType === 'music') {
           // Generate music signal
           const musicSignal = generateMusicSignal(duration * DEFAULT_CONFIG.sampleRate, DEFAULT_CONFIG.sampleRate);
-          frames = await generateSTFTFrames(musicSignal, DEFAULT_CONFIG, Math.floor(duration * 10));
+          // Convert duration to frame count using DEFAULT_GENERATED_FPS
+          frames = await generateSTFTFrames(
+            musicSignal,
+            DEFAULT_CONFIG,
+            Math.floor(duration * DEFAULT_GENERATED_FPS)
+          );
         } else if (dataType === 'mixed') {
           // Generate mixed signal
           const mixedSignal = generateMixedSignal(
@@ -342,7 +347,12 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
               { type: 'noise', amplitude: 0.2 }
             ]
           );
-          frames = await generateSTFTFrames(mixedSignal, DEFAULT_CONFIG, Math.floor(duration * 10));
+          // Convert duration to frame count using DEFAULT_GENERATED_FPS
+          frames = await generateSTFTFrames(
+            mixedSignal,
+            DEFAULT_CONFIG,
+            Math.floor(duration * DEFAULT_GENERATED_FPS)
+          );
         } else {
           // Generate single signal type
           const signal = generateSignalByType(
@@ -350,7 +360,12 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
             DEFAULT_CONFIG.sampleRate,
             dataType as SignalType
           );
-          frames = await generateSTFTFrames(signal, DEFAULT_CONFIG, Math.floor(duration * 10));
+          // Convert duration to frame count using DEFAULT_GENERATED_FPS
+          frames = await generateSTFTFrames(
+            signal,
+            DEFAULT_CONFIG,
+            Math.floor(duration * DEFAULT_GENERATED_FPS)
+          );
         }
         
         // Push frames to ring buffer

--- a/web/packages/viewer/src/utils/__tests__/generate-realistic-spectrogram-data.test.ts
+++ b/web/packages/viewer/src/utils/__tests__/generate-realistic-spectrogram-data.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test ensuring realistic data generation uses DEFAULT_GENERATED_FPS.
+ * What: Confirms frame count calculations rely on the shared constant.
+ * Why: Prevents accidental changes to synthetic data rate that could desync demos and tests.
+ * How: Generates data with mocked STFT and checks frame length.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock WASM binding so STFT processing is lightweight.
+vi.mock('@spectro/wasm-bindings', () => ({
+  stftFrame: vi.fn(async (data: Float32Array) => Float32Array.from(data)),
+}));
+
+import { DEFAULT_GENERATED_FPS } from '../../constants';
+
+const DataGenerator = await import('../data-generator');
+const { generateRealisticSpectrogramData } = DataGenerator;
+type SignalConfig = import('../data-generator').SignalConfig;
+type SignalType = import('../data-generator').SignalType;
+
+describe('generateRealisticSpectrogramData', () => {
+  it('produces frames at DEFAULT_GENERATED_FPS', async () => {
+    const config: SignalConfig = {
+      sampleRate: DEFAULT_GENERATED_FPS,
+      duration: 1,
+      windowSize: 1,
+      hopSize: 1,
+      windowType: 'hann',
+      reference: 1,
+    };
+    const types: SignalType[] = ['music', 'speech'];
+
+    const frames = await generateRealisticSpectrogramData(config, 2, types);
+
+    expect(frames).toHaveLength(types.length * DEFAULT_GENERATED_FPS);
+  });
+});

--- a/web/packages/viewer/src/utils/data-generator.ts
+++ b/web/packages/viewer/src/utils/data-generator.ts
@@ -5,6 +5,7 @@
  */
 
 import { stftFrame } from '@spectro/wasm-bindings';
+import { DEFAULT_GENERATED_FPS } from '../constants';
 
 /** Configuration for generating test signals. */
 export interface SignalConfig {
@@ -380,8 +381,12 @@ export async function generateRealisticSpectrogramData(
     // Generate signal for this segment
     const signal = generateSignalByType(segmentSamples, sampleRate, signalType);
     
-    // Process into STFT frames
-    const frames = await generateSTFTFrames(signal, config, Math.floor(segmentDuration * 10));
+    // Process into STFT frames at DEFAULT_GENERATED_FPS
+    const frames = await generateSTFTFrames(
+      signal,
+      config,
+      Math.floor(segmentDuration * DEFAULT_GENERATED_FPS)
+    );
     
     // Add type information and adjust timestamps
     const timeOffset = segmentIndex * segmentDuration;


### PR DESCRIPTION
## Summary
- centralize synthetic STFT frame rate with `DEFAULT_GENERATED_FPS`
- use the constant for frame count calculations in viewer and data generator
- add regression test for realistic data generation using the new constant

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck` *(fails: Cannot find type definition file for 'offscreencanvas'; plus other existing TS errors)*
- `pnpm --filter @spectro/viewer test`

------
https://chatgpt.com/codex/tasks/task_e_68a7255cbef4832bbae3fb70e3473fbb