### PR TITLE
fix(viewer): return immutable grid vertex data

### DIFF
--- a/web/packages/viewer/src/renderers/heatmap-2d.tsx
+++ b/web/packages/viewer/src/renderers/heatmap-2d.tsx
@@ -32,7 +32,7 @@ const GRID_MAX = 1;
  * Generate vertex arrays for the grid overlay.
  * What: Precomputes coordinates for horizontal and vertical grid lines as {@link Float32Array}s.
  * Why: Avoids per-render allocations and ensures stable geometry data.
- * How: Evenly interpolates positions between {@link GRID_MIN} and {@link GRID_MAX} for the given count.
+ * How: Validates inputs then evenly interpolates positions between {@link GRID_MIN} and {@link GRID_MAX} for the given count.
  */
 export function generateGridLineVertices(
   lineCount: number = GRID_LINE_COUNT,
@@ -41,6 +41,9 @@ export function generateGridLineVertices(
 ): { horizontal: Float32Array[]; vertical: Float32Array[] } {
   if (lineCount < 2) {
     throw new Error(`lineCount must be at least 2; got ${lineCount}`);
+  }
+  if (max <= min) {
+    throw new Error(`max must be greater than min; got min=${min}, max=${max}`);
   }
   const horizontal: Float32Array[] = [];
   const vertical: Float32Array[] = [];
@@ -56,16 +59,36 @@ export function generateGridLineVertices(
  * Precomputed grid line vertex arrays reused across renders.
  * What: Memoizes geometry data at module load.
  * Why: Prevents repeated allocation of identical vertex buffers.
+ * How: Generated once and frozen to guard against accidental mutation.
  */
-const GRID_LINE_VERTICES = generateGridLineVertices();
+const GRID_LINE_VERTICES = Object.freeze(generateGridLineVertices());
 
 /**
  * Retrieve precomputed grid line vertices.
  * What: Exposes memoized geometry data.
  * Why: Enables reuse and testing of the cached vertex arrays.
  */
+/**
+ * Clone an array of vertex buffers.
+ * What: Produces deep copies of {@link Float32Array} entries.
+ * Why: Protects internal memoized geometry from external mutation.
+ * How: Uses {@link Float32Array#slice} to duplicate buffers.
+ */
+function cloneVertexArray(arrays: readonly Float32Array[]): Float32Array[] {
+  return arrays.map((array) => array.slice());
+}
+
+/**
+ * Retrieve precomputed grid line vertices.
+ * What: Exposes memoized geometry data to callers.
+ * Why: Allows tests and consumers to inspect grid layout without risking mutation of cached data.
+ * How: Returns deep copies of the internal arrays.
+ */
 export function getGridLineVertices() {
-  return GRID_LINE_VERTICES;
+  return {
+    horizontal: cloneVertexArray(GRID_LINE_VERTICES.horizontal),
+    vertical: cloneVertexArray(GRID_LINE_VERTICES.vertical)
+  };
 }
 
 /**

--- a/web/packages/viewer/test/grid-vertices.test.ts
+++ b/web/packages/viewer/test/grid-vertices.test.ts
@@ -12,12 +12,15 @@ const TEST_MIN = -1;
 /** Maximum coordinate for test grid geometry. */
 const TEST_MAX = 1;
 
-describe('grid line vertex memoization', () => {
-  it('reuses arrays across calls', () => {
+describe('grid line vertex immutability', () => {
+  it('returns deep copies to protect cached data', () => {
     const first = getGridLineVertices();
+    // Mutate the first copy and ensure the cache is unaffected
+    const MUTATION_VALUE = 9999; // arbitrary test sentinel
+    first.horizontal[0][0] = MUTATION_VALUE;
     const second = getGridLineVertices();
-    expect(second.horizontal[0]).toBe(first.horizontal[0]);
-    expect(second.vertical[0]).toBe(first.vertical[0]);
+    expect(second.horizontal[0][0]).toBe(TEST_MIN);
+    expect(second.horizontal[0]).not.toBe(first.horizontal[0]);
   });
 
   it('matches expected grid geometry values', () => {
@@ -29,6 +32,11 @@ describe('grid line vertex memoization', () => {
 
   it('throws on invalid grid line count', () => {
     expect(() => generateGridLineVertices(1, TEST_MIN, TEST_MAX)).toThrow();
+  });
+
+  it('throws when max is not greater than min', () => {
+    expect(() => generateGridLineVertices(TEST_LINE_COUNT, TEST_MIN, TEST_MIN)).toThrow();
+    expect(() => generateGridLineVertices(TEST_LINE_COUNT, TEST_MAX, TEST_MIN)).toThrow();
   });
 });
 

--- a/web/packages/viewer/tsconfig.json
+++ b/web/packages/viewer/tsconfig.json
@@ -9,6 +9,8 @@
     "lib": ["ES2020", "DOM"],
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Exclude test sources to avoid requiring vitest globals during library type checking.
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**/*"]
 }
 


### PR DESCRIPTION
## Summary
- deep copy grid vertex arrays to avoid external mutation
- validate grid generation bounds
- exclude test sources from viewer typecheck

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for 'offscreencanvas'; ArrayBufferView mismatch; missing WebGL constants)*
- `pnpm test` *(fails: wasm-pack not found)*
- `pnpm --filter @spectro/viewer test`


------
https://chatgpt.com/codex/tasks/task_e_68a7255f906c832b97cf94b28b2fc209