### PR TITLE
Validate palette selection in playground

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,15 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@5.4.19(@types/node@20.19.11))
+      '@vitest/coverage-v8':
+        specifier: ^1.6.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.11)(jsdom@24.1.3))
       vite:
         specifier: ^5.3.0
         version: 5.4.19(@types/node@20.19.11)
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.11)(jsdom@24.1.3)
 
   web/packages/viewer:
     dependencies:

--- a/web/apps/playground/package.json
+++ b/web/apps/playground/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "react": "^18",
@@ -17,7 +18,9 @@
     "vite": "^5.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "vitest": "^1.6.0",
+    "@vitest/coverage-v8": "^1.6.0"
   }
 }
 

--- a/web/apps/playground/src/__mocks__/wasm.ts
+++ b/web/apps/playground/src/__mocks__/wasm.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal stub of WASM bindings for tests.
+ * What: Exposes dummy implementations of exported functions.
+ * Why: The real WASM module requires compilation and is unnecessary for unit tests.
+ */
+export const stftFrame = () => ({ magnitudes: new Float32Array() });

--- a/web/apps/playground/src/palette-utils.ts
+++ b/web/apps/playground/src/palette-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Palette utilities for the playground UI.
+ * What: Defines available palettes and validation helpers.
+ * Why: Centralizes palette management and prevents magic strings.
+ * How: Exports typed constants and runtime guards.
+ */
+import type { PaletteName } from '@spectro/viewer';
+
+/**
+ * All palettes supported by the playground.
+ * What: List of palette value/label pairs.
+ * Why: Ensures the select input stays in sync with viewer capabilities.
+ * How: Declared as a readonly array for immutability and type safety.
+ */
+export const PALETTE_OPTIONS: ReadonlyArray<{ value: PaletteName; label: string }> = [
+  { value: 'viridis', label: 'Viridis' },
+  { value: 'magma', label: 'Magma' },
+  { value: 'inferno', label: 'Inferno' },
+  { value: 'plasma', label: 'Plasma' },
+  { value: 'cividis', label: 'Cividis' },
+  { value: 'coolwarm', label: 'Coolwarm' },
+  { value: 'twilight', label: 'Twilight' },
+  { value: 'turbo', label: 'Turbo' }
+] as const;
+
+/**
+ * Default palette when none is specified.
+ * What: Initial palette used on app load.
+ * Why: Provides a safe fallback that is perceptually uniform.
+ * How: Exposed as a constant to avoid repeated string literals.
+ */
+export const DEFAULT_PALETTE: PaletteName = 'viridis';
+
+/**
+ * Cached list of palette values for quick membership tests.
+ * What: Extracts the value property from {@link PALETTE_OPTIONS}.
+ * Why: Avoids recomputation during validation and reduces memory churn.
+ * How: Uses map once at module load and stores as readonly tuple.
+ */
+const PALETTE_VALUES: readonly PaletteName[] = PALETTE_OPTIONS.map(p => p.value);
+
+/**
+ * Determine whether a string is a valid {@link PaletteName}.
+ * What: Runtime type guard for palette names.
+ * Why: Protects against DOM tampering and programming errors.
+ * How: Checks membership within {@link PALETTE_VALUES}.
+ */
+export function isPaletteName(value: string): value is PaletteName {
+  return (PALETTE_VALUES as readonly string[]).includes(value);
+}

--- a/web/apps/playground/src/playground-app.tsx
+++ b/web/apps/playground/src/playground-app.tsx
@@ -3,7 +3,14 @@ import { Spectrogram, type SpectroConfig, type SpectrogramAPI, DEFAULT_BG } from
 import { PaletteDemo } from './palette-demo';
 import { WasmTest } from './wasm-test';
 import type { SignalType } from '@spectro/viewer';
+import { PALETTE_OPTIONS, isPaletteName, DEFAULT_PALETTE } from './palette-utils';
 
+/**
+ * Supported synthetic signal presets.
+ * What: Options exposed to the demo data generator.
+ * Why: Keeps the UI selection synchronized with available signal types.
+ * How: Array of value/label/description tuples typed for safety.
+ */
 const signalTypes: Array<{ value: SignalType | 'mixed' | 'music' | 'realistic'; label: string; description: string }> = [
   { value: 'realistic', label: 'Realistic', description: 'Varied signals: music, speech, noise, chirp, tones' },
   { value: 'music', label: 'Music', description: 'Chord progressions with harmonics' },
@@ -30,7 +37,7 @@ export const PlaygroundApp: React.FC = () => {
       width: 800,
       height: 400,
       timeWindowSec: 10,
-      palette: 'viridis',
+      palette: DEFAULT_PALETTE,
       dbFloor: -100,
       dbCeiling: 0,
       showLegend: true,
@@ -54,14 +61,32 @@ export const PlaygroundApp: React.FC = () => {
     return () => clearInterval(interval);
   }, []);
 
+  /**
+   * Capture the viewer API once initialization completes.
+   * What: Stores the {@link SpectrogramAPI} reference for later use.
+   * Why: Other handlers need access to invoke rendering operations.
+   * How: Writes the provided API instance into a mutable ref.
+   */
   const handleReady = (api: SpectrogramAPI) => {
     apiRef.current = api;
   };
 
+  /**
+   * Remove all currently buffered spectrogram frames.
+   * What: Calls {@link SpectrogramAPI.clear}.
+   * Why: Resets the visualization to an empty state for new data.
+   * How: Uses optional chaining to avoid errors before initialization.
+   */
   const handleClearData = () => {
     apiRef.current?.clear();
   };
 
+  /**
+   * Save the current spectrogram view as a PNG image.
+   * What: Leverages {@link SpectrogramAPI.exportPNG} to generate a Blob.
+   * Why: Allows users to download snapshots of the visualization.
+   * How: Creates a temporary anchor element to trigger the download.
+   */
   const handleExportPNG = async () => {
     try {
       const blob = await apiRef.current?.exportPNG();
@@ -78,6 +103,12 @@ export const PlaygroundApp: React.FC = () => {
     }
   };
 
+  /**
+   * Request synthetic data generation from the viewer.
+   * What: Wraps API call to produce demo frames of the given signal type.
+   * Why: Exposes generation to UI controls while handling missing API safely.
+   * How: Defers to {@link SpectrogramAPI.generateData} if the API ref is set.
+   */
   const handleGenerateData = async (type?: SignalType | 'mixed' | 'music' | 'realistic') => {
     await apiRef.current?.generateData(type);
   };
@@ -317,11 +348,18 @@ export const PlaygroundApp: React.FC = () => {
                   Color Palette:
                 </label>
                 <select
-                  value={typeof config.palette === 'string' ? config.palette : 'viridis'}
-                  onChange={(e) => setConfig(prev => ({ 
-                    ...prev, 
-                    palette: e.target.value as any 
-                  }))}
+                  value={typeof config.palette === 'string' ? config.palette : DEFAULT_PALETTE}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (isPaletteName(value)) {
+                      setConfig(prev => ({
+                        ...prev,
+                        palette: value
+                      }));
+                    } else {
+                      console.warn(`Ignoring invalid palette "${value}"`);
+                    }
+                  }}
                   style={{
                     width: '100%',
                     padding: '8px',
@@ -331,14 +369,11 @@ export const PlaygroundApp: React.FC = () => {
                     borderRadius: '4px'
                   }}
                 >
-                  <option value="viridis">Viridis</option>
-                  <option value="magma">Magma</option>
-                  <option value="inferno">Inferno</option>
-                  <option value="plasma">Plasma</option>
-                  <option value="cividis">Cividis</option>
-                  <option value="coolwarm">Coolwarm</option>
-                  <option value="twilight">Twilight</option>
-                  <option value="turbo">Turbo</option>
+                  {PALETTE_OPTIONS.map(p => (
+                    <option key={p.value} value={p.value}>
+                      {p.label}
+                    </option>
+                  ))}
                 </select>
               </div>
 

--- a/web/apps/playground/test/palette-utils.test.ts
+++ b/web/apps/playground/test/palette-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { isPaletteName, PALETTE_OPTIONS } from '../src/palette-utils';
+
+/**
+ * Arbitrary invalid palette name used for negative tests.
+ */
+const INVALID_PALETTE = 'not-a-palette';
+
+describe('isPaletteName', () => {
+  it('accepts all declared palette options', () => {
+    for (const { value } of PALETTE_OPTIONS) {
+      expect(isPaletteName(value)).toBe(true);
+    }
+  });
+
+  it('rejects unrecognized palette names', () => {
+    expect(isPaletteName(INVALID_PALETTE)).toBe(false);
+  });
+});

--- a/web/apps/playground/vitest.config.ts
+++ b/web/apps/playground/vitest.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Helper to build absolute paths relative to this config file.
+const r = (p: string) => resolve(fileURLToPath(new URL('.', import.meta.url)), p);
+
+/**
+ * Vitest configuration for the playground app.
+ * What: Runs lightweight unit tests in a Node environment.
+ * Why: Ensures utility helpers behave correctly with coverage metrics.
+ * How: Enforces minimum coverage thresholds for confidence.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Stub WASM bindings to avoid compiling native code during tests.
+      '@spectro/wasm-bindings': r('./src/__mocks__/wasm.ts')
+    }
+  },
+  test: {
+    environment: 'node',
+    // Only run tests in the dedicated test directory.
+    include: ['test/**/*.test.ts'],
+    // Exclude legacy test scaffold lacking assertions.
+    exclude: ['src/wasm-test.test.ts'],
+    coverage: {
+      reporter: ['text', 'html'],
+      include: ['src/palette-utils.ts'],
+      lines: 50,
+      functions: 50,
+      statements: 50,
+      branches: 50
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- type-safe palette selection using PaletteName union
- centralize palette options and default
- add tests for palette validation with full coverage

## Testing
- `pnpm test` *(fails: wasm-pack not found)*
- `pnpm --filter @spectro/playground test`
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck` *(fails: TS errors in viewer package)*

------
https://chatgpt.com/codex/tasks/task_e_68a7255724dc832ba264e14cb95f222c