### PR TITLE
feat: validate ring buffer dimensions

### DIFF
--- a/web/packages/viewer/src/core/ring-buffer.test.ts
+++ b/web/packages/viewer/src/core/ring-buffer.test.ts
@@ -56,6 +56,26 @@ const GL_WEBGL1_NO_LINEAR = new FakeWebGL1Context({
 const BIN_COUNT = 3;
 /** Standard row capacity for buffers under test. */
 const MAX_ROWS = 4;
+/**
+ * Invalid dimension combinations exercised to validate constructor and resize checks.
+ * Each case specifies problematic values and the expected error fragment.
+ */
+const INVALID_DIMENSION_CASES: Array<{
+  binCount: number;
+  maxRows: number;
+  message: RegExp;
+}> = [
+  { binCount: 0, maxRows: 1, message: /binCount/ },
+  { binCount: -1, maxRows: 1, message: /binCount/ },
+  { binCount: Infinity, maxRows: 1, message: /binCount/ },
+  { binCount: NaN, maxRows: 1, message: /binCount/ },
+  { binCount: 1.5, maxRows: 1, message: /binCount/ },
+  { binCount: 1, maxRows: 0, message: /maxRows/ },
+  { binCount: 1, maxRows: -1, message: /maxRows/ },
+  { binCount: 1, maxRows: Infinity, message: /maxRows/ },
+  { binCount: 1, maxRows: NaN, message: /maxRows/ },
+  { binCount: 1, maxRows: 1.5, message: /maxRows/ },
+];
 
 /**
  * Verify R32F data is stored and typed correctly with WebGL2.
@@ -237,4 +257,37 @@ test('resize reinitializes internal storage', () => {
   expect(buffer.getTexture().image.width).toBe(4);
   expect(buffer.getTexture().image.height).toBe(3);
 });
+
+/**
+ * Ensure constructor rejects invalid dimensions.
+ */
+test.each(INVALID_DIMENSION_CASES)(
+  'constructor throws for invalid dimensions %#',
+  ({ binCount, maxRows, message }) => {
+    const config: RingBufferConfig = {
+      binCount,
+      maxRows,
+      format: 'UNORM8',
+      linearFilter: false,
+    };
+    expect(() => new SpectroRingBuffer(GL_WEBGL1_NO_EXT, config)).toThrow(message);
+  }
+);
+
+/**
+ * Ensure resize rejects invalid dimensions.
+ */
+test.each(INVALID_DIMENSION_CASES)(
+  'resize throws for invalid dimensions %#',
+  ({ binCount, maxRows, message }) => {
+    const config: RingBufferConfig = {
+      binCount: BIN_COUNT,
+      maxRows: MAX_ROWS,
+      format: 'UNORM8',
+      linearFilter: false,
+    };
+    const buffer = new SpectroRingBuffer(GL_WEBGL1_NO_EXT, config);
+    expect(() => buffer.resize(binCount, maxRows)).toThrow(message);
+  }
+);
 

--- a/web/packages/viewer/src/core/ring-buffer.ts
+++ b/web/packages/viewer/src/core/ring-buffer.ts
@@ -16,6 +16,8 @@ const TEXTURE_TYPE_BY_FORMAT: Record<RingBufferConfig['format'], THREE.TextureDa
 const UINT8_MAX = 255;
 /** Maximum value of an unsigned 16-bit integer for normalization. */
 const UINT16_MAX = 65535;
+/** Minimum permissible value for dimensional parameters to prevent empty buffers. */
+const MIN_DIMENSION = 1;
 
 /** Configuration describing ring buffer behaviour. */
 export interface RingBufferConfig {
@@ -53,7 +55,8 @@ export class SpectroRingBuffer {
   /**
    * Construct a ring buffer bound to a WebGL context.
    * @param gl - Rendering context used for uploads.
-   * @param config - Behavioural configuration.
+   * @param config - Behavioural configuration where {@link RingBufferConfig.binCount} and
+   * {@link RingBufferConfig.maxRows} must be finite positive integers.
    */
   constructor(gl: WebGLRenderingContext, config: RingBufferConfig) {
     this.gl = gl;
@@ -61,6 +64,7 @@ export class SpectroRingBuffer {
     this.verifyFloatTextureSupport();
 
     const { binCount, maxRows } = this.config;
+    this.validateDimensions(binCount, maxRows);
     this.data = this.createDataArray(binCount * maxRows);
     this.scratch = new Float32Array(binCount);
     this.texture = this.createTexture(this.data, binCount, maxRows);
@@ -131,6 +135,21 @@ export class SpectroRingBuffer {
     texture.minFilter = filter;
     texture.needsUpdate = true;
     return texture;
+  }
+
+  /**
+   * Ensure provided dimensions are finite positive integers.
+   * @param binCount - Desired number of frequency bins per row.
+   * @param maxRows - Desired number of rows to allocate.
+   * @throws When either dimension is non-integer, non-finite, or below {@link MIN_DIMENSION}.
+   */
+  private validateDimensions(binCount: number, maxRows: number): void {
+    if (!Number.isFinite(binCount) || !Number.isInteger(binCount) || binCount < MIN_DIMENSION) {
+      throw new Error('binCount must be a finite positive integer.');
+    }
+    if (!Number.isFinite(maxRows) || !Number.isInteger(maxRows) || maxRows < MIN_DIMENSION) {
+      throw new Error('maxRows must be a finite positive integer.');
+    }
   }
 
   /**
@@ -217,13 +236,15 @@ export class SpectroRingBuffer {
 
   /**
    * Resize the buffer, discarding existing data.
-   * @param binCount - New number of frequency bins.
-   * @param maxRows - New maximum number of rows.
+   * @param binCount - New number of frequency bins; must be a finite positive integer.
+   * @param maxRows - New maximum number of rows; must be a finite positive integer.
+   * @throws When either parameter fails validation.
    */
   resize(binCount: number, maxRows: number): void {
     if (binCount === this.config.binCount && maxRows === this.config.maxRows) {
       return;
     }
+    this.validateDimensions(binCount, maxRows);
     this.data = this.createDataArray(binCount * maxRows);
     this.scratch = new Float32Array(binCount);
     this.texture.dispose();


### PR DESCRIPTION
## Summary
- ensure ring buffer dimensions are finite positive integers before allocation or resize
- document dimension requirements and add coverage for invalid values

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test` *(fails: wasm-pack not found)*
- `pnpm --filter @spectro/viewer test`
- `pnpm --filter @spectro/viewer typecheck` *(fails: TS2304 cannot find name 'expect', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7255de728832b9726c1a45849609a