### PR TITLE
Remove unused onClick prop from viewer component

### DIFF
--- a/web/packages/viewer/src/index.tsx
+++ b/web/packages/viewer/src/index.tsx
@@ -148,9 +148,10 @@ export type SpectrogramProps = {
   config?: SpectroConfig;
   className?: string;
   style?: React.CSSProperties;
+  /** Callback fired once the renderer is ready and API initialized. */
   onReady?(api: SpectrogramAPI): void;
+  /** Callback delivering cursor sample information during hover interactions. */
   onHover?(p: { timeSec: number; freqHz: number; mag: number; magDb?: number; bin: number; row: number }): void;
-  onClick?(p: any): void;
 };
 
 /**
@@ -163,8 +164,7 @@ export const Spectrogram: React.FC<SpectrogramProps> = ({
   className,
   style,
   onReady,
-  onHover,
-  onClick
+  onHover
 }) => {
   const canvasRef = React.useRef<HTMLDivElement>(null);
   /** Renderer supplied by react-three-fiber. */


### PR DESCRIPTION
## Summary
- drop unimplemented `onClick` prop from `Spectrogram` API
- document hover callback after click removal

## Testing
- `pnpm --filter @spectro/viewer lint`
- `pnpm --filter @spectro/viewer test`
- `pnpm --filter @spectro/viewer typecheck` *(fails: Argument of type 'ArrayBufferView<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource')*

------
https://chatgpt.com/codex/tasks/task_e_68a725620398832b8d370bf129d5926f