### PR TITLE
Add typed wasm bindings and remove ts-ignore from loader

### DIFF
--- a/web/packages/wasm-bindings/pkg/spectro_dsp.d.ts
+++ b/web/packages/wasm-bindings/pkg/spectro_dsp.d.ts
@@ -1,0 +1,58 @@
+/**
+ * Type declarations for the wasm-bindgen generated spectro_dsp package.
+ * What: exposes the subset of exports consumed by the TypeScript wrapper.
+ * Why: provides static typing so consumers no longer require ts-ignore hacks.
+ */
+
+/**
+ * Perform a forward real-to-complex FFT.
+ * @param input Real-valued time-domain samples.
+ * @returns Interleaved complex spectrum [re0, im0, re1, im1, ...].
+ */
+export function fft_real(input: Float32Array): Float32Array;
+
+/**
+ * Apply a named window function to the input buffer.
+ * @param input Buffer to window in-place.
+ * @param window_type Name of the window (e.g., "hann").
+ * @returns Windowed buffer.
+ */
+export function apply_window(input: Float32Array, window_type: string): Float32Array;
+
+/**
+ * Compute a single short-time Fourier transform frame.
+ * @param input Time-domain samples for the frame.
+ * @param window_type Window to apply prior to FFT.
+ * @param reference Reference magnitude for dBFS conversion.
+ * @returns Magnitude spectrum for the frame.
+ */
+export function stft_frame(
+  input: Float32Array,
+  window_type: string,
+  reference: number
+): Float32Array;
+
+/**
+ * Convert a real block into its magnitude spectrum in dBFS.
+ * @param input Real-valued samples to analyse.
+ * @param reference Reference magnitude for dBFS conversion.
+ * @returns Magnitude spectrum in dBFS.
+ */
+export function magnitude_dbfs(
+  input: Float32Array,
+  reference: number
+): Float32Array;
+
+/**
+ * Exposed linear memory for low-level diagnostics.
+ */
+export const memory: WebAssembly.Memory;
+
+/**
+ * Initialise the underlying WebAssembly module.
+ * @param module_or_path Optional path or precompiled module to load.
+ * @returns Resolves when the module has been initialised.
+ */
+export default function init(
+  module_or_path?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module
+): Promise<void>;

--- a/web/packages/wasm-bindings/src/index.ts
+++ b/web/packages/wasm-bindings/src/index.ts
@@ -58,17 +58,17 @@ export async function initWasm(): Promise<WasmModule> {
 
   initPromise = (async () => {
     try {
-      // WASM loader lacks type declarations; ignore for type checking.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore – wasm-pack generated module has no types.
-      const mod = await import(WASM_PKG_JS_PATH);
+      // Import the wasm-bindgen module with its TypeScript declarations.
+      const mod = (await import(
+        WASM_PKG_JS_PATH
+      )) as typeof import('../pkg/spectro_dsp.js');
       if (!mod?.default || typeof mod.default !== 'function') {
         initPromise = null;
         throw new Error('WASM module missing default initialization function');
       }
       await mod.default();
       // After initialization the module functions are ready to use.
-      wasmModule = mod as unknown as WasmModule;
+      wasmModule = mod as WasmModule;
       return wasmModule;
     } catch (error) {
       // Reset promise on failure to allow subsequent retries.


### PR DESCRIPTION
## Summary
- add TypeScript declarations for spectro_dsp wasm module
- use typed import in initWasm and drop ts-ignore

## Testing
- `pnpm --filter @spectro/wasm-bindings format`
- `pnpm --filter @spectro/wasm-bindings lint`
- `pnpm --filter @spectro/wasm-bindings exec tsc --noEmit`
- `pnpm --filter @spectro/wasm-bindings test`


------
https://chatgpt.com/codex/tasks/task_e_68a7257215c4832b90fbf5b64bead2dd