### PR TITLE
Expose WASM buffers with optional reuse

### DIFF
--- a/web/packages/wasm-bindings/src/index.ts
+++ b/web/packages/wasm-bindings/src/index.ts
@@ -11,7 +11,11 @@ interface WasmModule {
   /** Apply a window function to the input buffer. */
   apply_window(input: Float32Array, window_type: string): Float32Array;
   /** Full STFT frame: window + FFT + magnitude. */
-  stft_frame(input: Float32Array, window_type: string, reference: number): Float32Array;
+  stft_frame(
+    input: Float32Array,
+    window_type: string,
+    reference: number,
+  ): Float32Array;
   /** Magnitude spectrum computation in dBFS. */
   magnitude_dbfs(input: Float32Array, reference: number): Float32Array;
   /** Exposed linear memory for low level diagnostics. */
@@ -43,10 +47,18 @@ const FAILED_TO_FETCH_MSG = 'Failed to fetch';
 /** Substring present in Firefox network failures. */
 const NETWORK_ERROR_MSG = 'NetworkError';
 
+/** Default reference level used when converting to dBFS. */
+const DEFAULT_REFERENCE_LEVEL = 1.0;
+
 /** Cached WASM module once initialised for reuse across calls. */
 let wasmModule: WasmModule | null = null;
 /** Tracks ongoing initialization to deduplicate concurrent requests. */
 let initPromise: Promise<WasmModule> | null = null;
+
+/**
+ * Ownership: arrays returned by exported helpers view the module's linear memory.
+ * If persistent data is needed, pass an `output` buffer or copy the result.
+ */
 
 /**
  * Initialize the WASM module (idempotent).
@@ -92,26 +104,48 @@ export async function initWasm(): Promise<WasmModule> {
 
 /**
  * Compute FFT (real→complex interleaved) via WASM.
- * Validates input prior to dispatch.
+ * What: forwards to the Rust implementation without copying by default.
+ * Why: callers may reuse the returned buffer directly to avoid allocations.
+ * How: optionally copies into `output` when provided to retain ownership.
  */
-export async function fftReal(input: Float32Array): Promise<Float32Array> {
+export async function fftReal(
+  input: Float32Array,
+  output?: Float32Array,
+): Promise<Float32Array> {
   if (!(input instanceof Float32Array)) {
     throw new TypeError('fftReal expects a Float32Array input');
   }
   if (input.length === 0) {
     throw new Error('fftReal requires a non-empty input array');
   }
+  if (output !== undefined && !(output instanceof Float32Array)) {
+    throw new TypeError('fftReal output buffer must be a Float32Array');
+  }
   const wasm = await initWasm();
-  return wasm.fft_real(input).slice();
+  const result = wasm.fft_real(input);
+  if (output) {
+    if (output.length !== result.length) {
+      throw new Error(
+        `fftReal output length ${output.length} does not match ${result.length}`,
+      );
+    }
+    output.set(result);
+    return output;
+  }
+  // The returned array views WASM memory that may be reused; copy or supply `output` to retain data.
+  return result;
 }
 
 /**
  * Apply a window function to the input buffer via WASM.
- * Ensures the window type is recognised.
+ * What: delegates to Rust windowing without copying unless `output` supplied.
+ * Why: allows callers to reuse buffers and control ownership of data.
+ * How: writes into `output` when provided; otherwise returns a view into WASM memory.
  */
 export async function applyWindow(
   input: Float32Array,
   windowType: 'hann' | 'hamming' | 'blackman' | 'none',
+  output?: Float32Array,
 ): Promise<Float32Array> {
   if (!(input instanceof Float32Array)) {
     throw new TypeError('applyWindow expects a Float32Array input');
@@ -122,19 +156,36 @@ export async function applyWindow(
   if (!WINDOW_TYPES.includes(windowType)) {
     throw new Error(`Unknown window type: ${windowType}`);
   }
+  if (output !== undefined && !(output instanceof Float32Array)) {
+    throw new TypeError('applyWindow output buffer must be a Float32Array');
+  }
   const wasm = await initWasm();
   const resolvedType = windowType === 'none' ? 'rect' : windowType;
-  return wasm.apply_window(input, resolvedType).slice();
+  const result = wasm.apply_window(input, resolvedType);
+  if (output) {
+    if (output.length !== result.length) {
+      throw new Error(
+        `applyWindow output length ${output.length} does not match ${result.length}`,
+      );
+    }
+    output.set(result);
+    return output;
+  }
+  // Returned array aliases WASM memory that may be recycled; provide `output` or copy to keep values.
+  return result;
 }
 
 /**
  * Compute complete STFT frame: window + FFT + magnitude via WASM.
- * Validates parameters before invoking the Rust routine.
+ * What: performs the entire pipeline while avoiding copies unless `output` is given.
+ * Why: callers can reuse buffers or retain results deterministically.
+ * How: copies into `output` when provided; otherwise returns WASM memory directly.
  */
 export async function stftFrame(
   input: Float32Array,
   windowType: 'hann' | 'hamming' | 'blackman' | 'none',
-  reference = 1.0,
+  reference: number = DEFAULT_REFERENCE_LEVEL,
+  output?: Float32Array,
 ): Promise<Float32Array> {
   if (!(input instanceof Float32Array)) {
     throw new TypeError('stftFrame expects a Float32Array input');
@@ -148,18 +199,35 @@ export async function stftFrame(
   if (!Number.isFinite(reference) || reference <= 0) {
     throw new Error('reference must be a positive finite number');
   }
+  if (output !== undefined && !(output instanceof Float32Array)) {
+    throw new TypeError('stftFrame output buffer must be a Float32Array');
+  }
   const wasm = await initWasm();
   const resolvedType = windowType === 'none' ? 'rect' : windowType;
-  return wasm.stft_frame(input, resolvedType, reference).slice();
+  const result = wasm.stft_frame(input, resolvedType, reference);
+  if (output) {
+    if (output.length !== result.length) {
+      throw new Error(
+        `stftFrame output length ${output.length} does not match ${result.length}`,
+      );
+    }
+    output.set(result);
+    return output;
+  }
+  // The returned array references WASM memory that may be overwritten later; copy or use `output` to persist.
+  return result;
 }
 
 /**
  * Compute magnitude spectrum in dBFS from a real block in WASM.
- * Ensures numeric parameters are valid before dispatch.
+ * What: performs only magnitude conversion with optional copy into `output`.
+ * Why: callers may reuse buffers to avoid allocations and maintain ownership.
+ * How: returns WASM memory directly when no `output` is supplied.
  */
 export async function magnitudeDbfs(
   input: Float32Array,
-  reference = 1.0,
+  reference: number = DEFAULT_REFERENCE_LEVEL,
+  output?: Float32Array,
 ): Promise<Float32Array> {
   if (!(input instanceof Float32Array)) {
     throw new TypeError('magnitudeDbfs expects a Float32Array input');
@@ -170,8 +238,22 @@ export async function magnitudeDbfs(
   if (!Number.isFinite(reference) || reference <= 0) {
     throw new Error('reference must be a positive finite number');
   }
+  if (output !== undefined && !(output instanceof Float32Array)) {
+    throw new TypeError('magnitudeDbfs output buffer must be a Float32Array');
+  }
   const wasm = await initWasm();
-  return wasm.magnitude_dbfs(input, reference).slice();
+  const result = wasm.magnitude_dbfs(input, reference);
+  if (output) {
+    if (output.length !== result.length) {
+      throw new Error(
+        `magnitudeDbfs output length ${output.length} does not match ${result.length}`,
+      );
+    }
+    output.set(result);
+    return output;
+  }
+  // Result aliases WASM memory that may be recycled; copy or use `output` to retain values.
+  return result;
 }
 
 /** Spectro meta DTO mirrored from Rust for convenience. */

--- a/web/packages/wasm-bindings/test/wasm-bindings.test.ts
+++ b/web/packages/wasm-bindings/test/wasm-bindings.test.ts
@@ -153,3 +153,57 @@ test('WASM bindings execute and validate inputs', async () => {
   await assert.rejects(() => stftFrame(new Float32Array([1]), 'hann', 0));
   await assert.rejects(() => magnitudeDbfs(new Float32Array([1]), -1));
 });
+
+/**
+ * Ensure wrappers expose raw WASM memory and support reusable output buffers.
+ */
+test('DSP routines support optional output buffers', async () => {
+  // --- fftReal ---
+  const input = makeInput();
+  const first = await fftReal(input);
+  const expectedFft = first.slice();
+  const fftOut = new Float32Array(first.length);
+  const fftWithOut = await fftReal(input, fftOut);
+  assert.strictEqual(fftWithOut, fftOut);
+  assert.deepEqual(fftOut, expectedFft);
+  await assert.rejects(() => fftReal(input, new Float32Array(fftOut.length + 1)));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await assert.rejects(() => fftReal(input, {} as any));
+
+  // --- applyWindow ---
+  const winFirst = await applyWindow(input, 'hann');
+  const expectedWin = winFirst.slice();
+  const winOut = new Float32Array(winFirst.length);
+  const winWithOut = await applyWindow(input, 'hann', winOut);
+  assert.strictEqual(winWithOut, winOut);
+  assert.deepEqual(winOut, expectedWin);
+  await assert.rejects(() => applyWindow(input, 'hann', new Float32Array(winOut.length + 1)));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await assert.rejects(() => applyWindow(input, 'hann', {} as any));
+
+  // --- stftFrame ---
+  const stftFirst = await stftFrame(input, 'hann');
+  const expectedStft = stftFirst.slice();
+  const stftOut = new Float32Array(stftFirst.length);
+  const stftWithOut = await stftFrame(input, 'hann', undefined, stftOut);
+  assert.strictEqual(stftWithOut, stftOut);
+  assert.deepEqual(stftOut, expectedStft);
+  await assert.rejects(() =>
+    stftFrame(input, 'hann', 1.0, new Float32Array(stftOut.length + 1)),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await assert.rejects(() => stftFrame(input, 'hann', 1.0, {} as any));
+
+  // --- magnitudeDbfs ---
+  const magFirst = await magnitudeDbfs(input);
+  const expectedMag = magFirst.slice();
+  const magOut = new Float32Array(magFirst.length);
+  const magWithOut = await magnitudeDbfs(input, undefined, magOut);
+  assert.strictEqual(magWithOut, magOut);
+  assert.deepEqual(magOut, expectedMag);
+  await assert.rejects(() =>
+    magnitudeDbfs(input, 1.0, new Float32Array(magOut.length + 1)),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await assert.rejects(() => magnitudeDbfs(input, 1.0, {} as any));
+});


### PR DESCRIPTION
## Summary
- allow fft, window, stft, and magnitude helpers to reuse caller-provided buffers
- document WASM memory ownership and clarify API expectations
- add coverage for optional output buffers

## Testing
- `pnpm --filter @spectro/wasm-bindings lint`
- `pnpm --filter @spectro/wasm-bindings test`


------
https://chatgpt.com/codex/tasks/task_e_68a7257f02a8832ba6d713ca3fc36466