### PR TITLE
feat(wasm-bindings): add wasm module types

### DIFF
--- a/web/packages/wasm-bindings/src/index.ts
+++ b/web/packages/wasm-bindings/src/index.ts
@@ -58,10 +58,10 @@ export async function initWasm(): Promise<WasmModule> {
 
   initPromise = (async () => {
     try {
-      // WASM loader lacks type declarations; ignore for type checking.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore – wasm-pack generated module has no types.
-      const mod = await import(WASM_PKG_JS_PATH);
+      // Dynamically import the wasm-bindgen module with explicit typing.
+      // What: cast the resolved module to the generated spectro_dsp types.
+      // Why: the import path is computed at runtime so TypeScript cannot infer it.
+      const mod = (await import(WASM_PKG_JS_PATH)) as typeof import('../pkg/spectro_dsp.js');
       if (!mod?.default || typeof mod.default !== 'function') {
         initPromise = null;
         throw new Error('WASM module missing default initialization function');

--- a/web/packages/wasm-bindings/src/types/spectro_dsp.d.ts
+++ b/web/packages/wasm-bindings/src/types/spectro_dsp.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Ambient type declarations for the wasm-bindgen generated spectro_dsp package.
+ * What: Exposes the subset of bindings required by this project.
+ * Why: wasm-pack output lacks TypeScript types, so dynamic imports were untyped.
+ * How: Declare the module's exports so consumers can import with full type safety.
+ */
+declare module '../pkg/spectro_dsp.js' {
+  /** Types accepted by the default initialization function. */
+  type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+  /** Forward real-to-complex FFT implemented in Rust. */
+  export function fft_real(input: Float32Array): Float32Array;
+
+  /** Apply a window function to the input buffer. */
+  export function apply_window(input: Float32Array, window_type: string): Float32Array;
+
+  /** Compute an STFT frame: windowing, FFT and magnitude. */
+  export function stft_frame(
+    input: Float32Array,
+    window_type: string,
+    reference: number
+  ): Float32Array;
+
+  /** Magnitude spectrum computation in dBFS. */
+  export function magnitude_dbfs(input: Float32Array, reference: number): Float32Array;
+
+  /** Exposed linear memory for low level diagnostics. */
+  export const memory: WebAssembly.Memory;
+
+  /** Initialise the WASM module, optionally providing a custom source. */
+  export default function init(input?: InitInput): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- declare spectro_dsp wasm-bindgen exports so dynamic import is typed
- remove ts-ignore and cast import to the declared module

## Testing
- `pnpm --filter @spectro/wasm-bindings lint`
- `pnpm --filter @spectro/wasm-bindings format`
- `pnpm --filter @spectro/wasm-bindings typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm --filter @spectro/wasm-bindings test`


------
https://chatgpt.com/codex/tasks/task_e_68a7257d5520832b96d047aec5b1c57d